### PR TITLE
ls.c: bugfixes and some code fixes

### DIFF
--- a/core/psh/ls.c
+++ b/core/psh/ls.c
@@ -93,10 +93,10 @@ struct winsize w;
 void ls_printHelp(void)
 {
 	const char help[] = "Command line arguments:\n"
-						"  -h:  prints help\n"
-						"  -l:  long listing format\n"
-						"  -1:  one entry per line\n"
-						"  -a:  do not ignore entries starting with .\n\n";
+			    "  -h:  prints help\n"
+			    "  -l:  long listing format\n"
+			    "  -1:  one entry per line\n"
+			    "  -a:  do not ignore entries starting with .\n\n";
 
 	printf(help);
 }
@@ -129,18 +129,16 @@ static size_t ls_initColinfo(size_t nfiles)
 				size_t idx =  filesno / ((nfiles + i) / (i + 1));
 				size_t real_length = name_length + (idx == i ? 0 : 2);
 				if (colinfo[i].colarr[idx] < real_length) {
-					colinfo[i].linelen += (real_length
-					                       - colinfo[i].colarr[idx]);
+					colinfo[i].linelen += (real_length - colinfo[i].colarr[idx]);
 					colinfo[i].colarr[idx] = real_length;
-					colinfo[i].validlen = (colinfo[i].linelen
-					                       < w.ws_col);
+					colinfo[i].validlen = (colinfo[i].linelen < w.ws_col);
 				}
 			}
 		}
 	}
 
-	/* Find maximum allowed columns.  */
-	for (cols = maxcols; 1 < cols; --cols) {
+	/* Find maximum allowed columns. */
+	for (cols = maxcols; cols > 1; --cols) {
 		if (colinfo[cols - 1].validlen)
 			break;
 	}
@@ -159,8 +157,7 @@ static void ls_colorPrint(struct fileinfo *file, size_t width)
 			printf(EXECCOLOR);
 	} else if (S_ISDIR(file->stat.st_mode)) {
 		printf(DIRCOLOR);
-	} else if (S_ISCHR(file->stat.st_mode) ||
-			   S_ISBLK(file->stat.st_mode)) {
+	} else if (S_ISCHR(file->stat.st_mode) || S_ISBLK(file->stat.st_mode)) {
 		printf(DEVCOLOR);
 	} else if (S_ISLNK(file->stat.st_mode)) {
 		printf(SYMCOLOR);
@@ -203,7 +200,6 @@ static int ls_namecpy(struct fileinfo *f, const char *name)
 	return 0;
 }
 
-
 static int ls_readEntry(struct fileinfo *f, struct dirent *dir, const char *path, unsigned int full)
 {
 	char *fullname;
@@ -229,7 +225,7 @@ static int ls_readEntry(struct fileinfo *f, struct dirent *dir, const char *path
 	}
 
 	if (lstat(fullname, &f->stat) != 0) {
-		printf("ls: Can't stat file %s error: %d\n", dir->d_name);
+		printf("ls: Can't stat file %s.\n", dir->d_name);
 		free(fullname);
 		return -1;
 	}
@@ -254,7 +250,7 @@ int ls_readFile(struct fileinfo *f, char *path, int full)
 
 
 	if (lstat(path, &f->stat) != 0) {
-		printf("ls: Can't stat file %s error: %d\n", path);
+		printf("ls: Can't stat file %s.\n", path);
 		return -1;
 	}
 
@@ -269,10 +265,12 @@ int ls_readFile(struct fileinfo *f, char *path, int full)
 static unsigned int ls_numPlaces(unsigned int n)
 {
 	size_t r = 1;
+
 	while (n > 9) {
 		n /= 10;
 		r++;
 	}
+
 	return r;
 }
 
@@ -312,9 +310,7 @@ static void ls_printLong(size_t nfiles)
 			perms[j] = '-';
 		perms[10] = '\0';
 
-		if (S_ISREG(files[i].stat.st_mode)) {
-			perms[0] = '-';
-		} else if (S_ISDIR(files[i].stat.st_mode)) {
+		if (S_ISDIR(files[i].stat.st_mode)) {
 			perms[0] = 'd';
 		} else if (S_ISCHR(files[i].stat.st_mode)) {
 			perms[0] = 'c';
@@ -426,8 +422,7 @@ static int ls_buffersInit(size_t sz)
 
 	files = malloc(sz * sizeof(struct fileinfo));
 	if (files == NULL) {
-		printf("ls: out of memory\n");
-		return -ENOMEM;
+		goto outMem;
 	}
 
 	for (i = 0; i < sz; i++) {
@@ -438,8 +433,7 @@ static int ls_buffersInit(size_t sz)
 
 	colinfo = malloc(maxcols * sizeof(struct colinfo));
 	if (colinfo == NULL) {
-		printf("ls: out of memory\n");
-		return -ENOMEM;
+		goto outMem;
 	}
 
 	for (i = 0; i < maxcols; i++)
@@ -449,13 +443,16 @@ static int ls_buffersInit(size_t sz)
 		colinfo[i].colarr = malloc((i + 1) * sizeof(size_t));
 
 		if (colinfo[i].colarr == NULL) {
-			printf("ls: out of memory\n");
-			return -ENOMEM;
+			goto outMem;
 		}
 	}
 	colinfoSize = maxcols;
 
 	return 0;
+
+outMem:
+	printf("ls: out of memory\n");
+	return -ENOMEM;
 }
 
 static int ls_bufferExpand(size_t sz)
@@ -466,8 +463,7 @@ static int ls_bufferExpand(size_t sz)
 
 	reptr = realloc(files, sz * sizeof(struct fileinfo));
 	if (reptr == NULL) {
-		printf("ls: out of memory\n");
-		return -ENOMEM;
+		goto outMem;
 	}
 
 	files = reptr;
@@ -480,8 +476,7 @@ static int ls_bufferExpand(size_t sz)
 	if (maxcols > colinfoSize) {
 		reptr = realloc(colinfo, maxcols * sizeof(struct colinfo));
 		if (reptr == NULL) {
-			printf("ls: out of memory\n");
-			return -ENOMEM;
+			goto outMem;
 		}
 		colinfo = reptr;
 
@@ -492,14 +487,17 @@ static int ls_bufferExpand(size_t sz)
 			colinfo[i].colarr = malloc((i + 1) * sizeof(size_t));
 
 			if (colinfo[i].colarr == NULL) {
-				printf("ls: out of memory\n");
-				return -ENOMEM;
+				goto outMem;
 			}
 		}
 		colinfoSize = maxcols;
 	}
 
 	return 0;
+
+outMem:
+	printf("ls: out of memory\n");
+	return -ENOMEM;
 }
 
 
@@ -532,21 +530,13 @@ int psh_ls(char *args)
 	/* Parse arguments */
 	while ((args = psh_nextString(args, &len)) && len) {
 		if (args[0] != '-') {
-			if (paths) {
-				reptr = realloc(paths, (npaths + 1) * sizeof(char *));
-				if (reptr == NULL) {
-					printf("ls: out of memory\n");
-					ret = -ENOMEM;
-					goto freePaths;
-				}
-				paths = reptr;
-			} else {
-				paths = malloc(sizeof(char *));
-				if (paths == NULL) {
-					printf("ls: out of memory\n");
-					return -ENOMEM;
-				}
+			reptr = realloc(paths, (npaths + 1) * sizeof(char *));
+			if (reptr == NULL) {
+				printf("ls: out of memory\n");
+				ret = -ENOMEM;
+				goto freePaths;
 			}
+			paths = reptr;
 
 			if ((paths[npaths] = strdup(args)) == NULL) {
 				printf("ls: out of memory\n");
@@ -634,13 +624,17 @@ int psh_ls(char *args)
 			if (dir->d_name[0] == '.' && !all)
 				continue;
 
-			if ((ret = ls_readEntry(&files[nfiles], dir, path, full)) != 0)
+			if ((ret = ls_readEntry(&files[nfiles], dir, path, full)) != 0) {
+				closedir(stream);
 				goto freePaths;
+			}
 
 			nfiles++;
 			if (nfiles == fileinfoSize) {
-				if ((ret = ls_bufferExpand(fileinfoSize * 2)) != 0)
+				if ((ret = ls_bufferExpand(fileinfoSize * 2)) != 0) {
+					closedir(stream);
 					goto freePaths;
+				}
 			}
 		}
 

--- a/core/psh/ls.c
+++ b/core/psh/ls.c
@@ -422,7 +422,8 @@ static int ls_buffersInit(size_t sz)
 
 	files = malloc(sz * sizeof(struct fileinfo));
 	if (files == NULL) {
-		goto outMem;
+		printf("ls: out of memory\n");
+		return -ENOMEM;
 	}
 
 	for (i = 0; i < sz; i++) {
@@ -433,7 +434,8 @@ static int ls_buffersInit(size_t sz)
 
 	colinfo = malloc(maxcols * sizeof(struct colinfo));
 	if (colinfo == NULL) {
-		goto outMem;
+		printf("ls: out of memory\n");
+		return -ENOMEM;
 	}
 
 	for (i = 0; i < maxcols; i++)
@@ -443,16 +445,13 @@ static int ls_buffersInit(size_t sz)
 		colinfo[i].colarr = malloc((i + 1) * sizeof(size_t));
 
 		if (colinfo[i].colarr == NULL) {
-			goto outMem;
+			printf("ls: out of memory\n");
+			return -ENOMEM;
 		}
 	}
 	colinfoSize = maxcols;
 
 	return 0;
-
-outMem:
-	printf("ls: out of memory\n");
-	return -ENOMEM;
 }
 
 static int ls_bufferExpand(size_t sz)
@@ -463,7 +462,8 @@ static int ls_bufferExpand(size_t sz)
 
 	reptr = realloc(files, sz * sizeof(struct fileinfo));
 	if (reptr == NULL) {
-		goto outMem;
+		printf("ls: out of memory\n");
+		return -ENOMEM;
 	}
 
 	files = reptr;
@@ -476,7 +476,8 @@ static int ls_bufferExpand(size_t sz)
 	if (maxcols > colinfoSize) {
 		reptr = realloc(colinfo, maxcols * sizeof(struct colinfo));
 		if (reptr == NULL) {
-			goto outMem;
+			printf("ls: out of memory\n");
+			return -ENOMEM;
 		}
 		colinfo = reptr;
 
@@ -487,17 +488,14 @@ static int ls_bufferExpand(size_t sz)
 			colinfo[i].colarr = malloc((i + 1) * sizeof(size_t));
 
 			if (colinfo[i].colarr == NULL) {
-				goto outMem;
+				printf("ls: out of memory\n");
+				return -ENOMEM;
 			}
 		}
 		colinfoSize = maxcols;
 	}
 
 	return 0;
-
-outMem:
-	printf("ls: out of memory\n");
-	return -ENOMEM;
 }
 
 


### PR DESCRIPTION
Major changes:
- `ls_readEntry()` - bug fixed
- `ls_readFile()` - bug fixed
- `ls_printLong()` - repeating `for`
- `psh_ls()` - `realloc()` with `NULL` pointer works as `malloc()`

In this version the `ls` command do not work if the argument is a directory.
