### PR TITLE
psh: fixed memory leak and some code changes

### DIFF
--- a/core/psh/cat.c
+++ b/core/psh/cat.c
@@ -55,8 +55,8 @@ int psh_cat(int argc, char **argv)
 		else {
 			while (!psh_common.sigint && !psh_common.sigquit && !psh_common.sigstop && ((ret = fread(buff, 1, 1024, file)) > 0))
 				fwrite(buff, 1, ret, stdout);
+			fclose(file);
 		}
-		fclose(file);
 	}
 	free(buff);
 

--- a/core/psh/kill.c
+++ b/core/psh/kill.c
@@ -30,7 +30,7 @@ int psh_kill(int argc, char **argv)
 	}
 
 	pid = strtoul(argv[1], &end, 10);
-	if ((end != (argv[1] + strlen(argv[1]))) || (pid == 0 && argv[1][0] != '0')) {
+	if ((*end != '\0') || (pid == 0 && argv[1][0] != '0')) {
 		printf("kill: could not parse process id: %s\n", argv[1]);
 		return -EINVAL;
 	}

--- a/core/psh/psh.c
+++ b/core/psh/psh.c
@@ -448,7 +448,6 @@ static int psh_readcmd(struct termios *orig, psh_hist_t *cmdhist, char **cmd)
 			}
 			/* TAB => autocomplete */
 			else if (c == '\t') {
-				
 			}
 			/* FF => clear screen */
 			else if (c == '\014') {
@@ -703,7 +702,7 @@ static int psh_runfile(char **argv)
 	case -ENOMEM:
 		printf("psh: out of memory\n");
 		break;
-		
+
 	case -EINVAL:
 		printf("psh: invalid executable\n");
 		break;
@@ -807,7 +806,7 @@ static int psh_exec(int argc, char **argv)
 	case -ENOMEM:
 		printf("psh: out of memory\n");
 		break;
-		
+
 	case -EINVAL:
 		printf("psh: invalid executable\n");
 		break;


### PR DESCRIPTION
### Changes:
- `psh_cat()` - fixed `fclose()` with `NULL` pointer
- `ps_kill()` - enough check `*end`
- `psh_ls_copyname()` - `realloc()` with `NULL' pointer works as `malloc()`
- `psh_ls_initbuffs()` and `psh_ls_expandbuf()` -  they are practically the same
- `psh_ls()` - fixed memory leak
- `psh.c` - removed trailing whitespaces

btw
Cast return value `malloc()` family functions is unnecessary and not recommended.
Error information should probably go to `stderr` and not `stdout`.
