### PR TITLE
Fix Makefile for using TARGET with platform suffix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,5 +40,5 @@ ifneq ($(T1),)
 $(T1):
 	@echo >/dev/null
 else
-	include _targets/Makefile.$(TARGET)
+	include _targets/Makefile.$(TARGET_FAMILY)-$(TARGET_SUBFAMILY)
 endif


### PR DESCRIPTION
TARGET=armv7m4-stm32l4x6
works ok, but
TARGET=armv7m4-stm32l4x6-myBoard
return an error – target not found.

This commit fixed it.

It's consistent with other repositories, eg. https://github.com/phoenix-rtos/phoenix-rtos-devices/blob/master/Makefile#L42