### PR TITLE
psh: login feature

### DIFF
--- a/core/psh/Makefile
+++ b/core/psh/Makefile
@@ -4,9 +4,9 @@
 # Copyright 2018, 2019, 2020, 2021 Phoenix Systems
 #
 
-OBJS = $(filter-out psh psh-empties, $(subst .c,,$(subst ./core/psh/,, $(shell find ./core/psh/ -name '*.c'))))
+OBJS = $(filter-out psh psh-empties login, $(subst .c,,$(subst ./core/psh/,, $(shell find ./core/psh/ -name '*.c'))))
 PSH_COMMANDS ?= $(OBJS)
-OBJ_FEATURED = $(addsuffix .o,$(filter $(PSH_COMMANDS),$(OBJS)))
+OBJ_FEATURED = $(addsuffix .o, $(if $(filter-out login,$(PSH_COMMANDS)) , $(PSH_COMMANDS) , $(if $(filter login,$(PSH_COMMANDS)),$(OBJS) login,$(OBJS)) ))
 
 $(PREFIX_PROG)psh: $(addprefix $(PREFIX_O)core/psh/, psh.o psh-empties.o $(OBJ_FEATURED))
 	$(LINK)

--- a/core/psh/login.c
+++ b/core/psh/login.c
@@ -1,0 +1,73 @@
+/*
+ * Phoenix-RTOS
+ *
+ * login - allows/disallows access to Phoenix SHell 
+ *
+ * Copyright 2021 Phoenix Systems
+ * Author: Mateusz Niewiadomski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "psh.h"
+
+
+int psh_login(void){
+	char c, *usrpasswd;
+	unsigned int passsz = 0;
+
+	/* allocate memory for user-given password */
+	if ((usrpasswd = calloc(strlen(psh_common.passwd),sizeof(char)+1)) == NULL )
+	{
+		fprintf(stderr,"psh: fail to allocate memory for login");
+		return -ENOMEM;
+	}
+
+	for (;;)
+	{
+		if( !passsz ){
+			printf("Enter password: ");
+			fflush(0);
+		}
+
+		read(STDIN_FILENO, &c, 1);
+
+		if ( c == '\n' )
+		{
+			if (  (passsz == strlen(psh_common.passwd)) && !strcmp(usrpasswd,psh_common.passwd) )
+			{
+				break;	/* correct password is given, success exit */
+			}
+			else
+			{
+				memset(usrpasswd,'\0',strlen(usrpasswd));
+				passsz=0;
+				fprintf(stderr,"psh: wrong password!\n");
+			}
+		}
+		else if ( passsz && ((c == '\b') || (c == '\177')) )
+		{
+			if( passsz < strlen(psh_common.passwd) )
+				usrpasswd[passsz--] = '\0';
+		}
+		else
+		{
+			if( passsz < strlen(psh_common.passwd) )
+				usrpasswd[passsz] = c;
+			passsz++;
+		}
+	}
+
+	free(usrpasswd);
+	printf("Correct password!\n");
+	return 0;
+}
+

--- a/core/psh/psh-empties.c
+++ b/core/psh/psh-empties.c
@@ -82,6 +82,11 @@ int __attribute__((weak)) psh_kill(int argc, char **argv)
 }
 
 
+int __attribute__((weak)) psh_login(void){
+	return 0;
+}
+
+
 void __attribute__((weak)) psh_lsinfo(void)
 {
 	return;

--- a/core/psh/psh.h
+++ b/core/psh/psh.h
@@ -19,7 +19,8 @@ typedef struct {
 	volatile unsigned char sigint;  /* Received SIGINT */
 	volatile unsigned char sigquit; /* Received SIGQUIT */
 	volatile unsigned char sigstop; /* Received SIGTSTP */
-	char* unkncmd;// = "Command not supported!\n";
+	char* unkncmd;
+	char* passwd;
 } psh_common_t;
 
 


### PR DESCRIPTION
Added login feature. Forbids psh usage if valid password is not given. Password stored in plain text in psh_commons. Feature not present by default.

Feature can be turned on if value "login" is added to PSH_COMMANDS shell variable in _targets scripts. If the only value in PSH_COMMANDS is "login" then all psh features + login are present. If variable PSH_COMMANDS is not declared then psh has all features except login feature.

Default password is "phoenix"

JIRA: BES-104