### PR TITLE
psh: sysexec whitelist feature

### DIFF
--- a/core/psh/Makefile
+++ b/core/psh/Makefile
@@ -4,9 +4,11 @@
 # Copyright 2018, 2019, 2020, 2021 Phoenix Systems
 #
 
-ifdef PSH_DEFUSRPWDHASH
+PSH_DEFUSRPWDHASH ?= ""
 CFLAGS += -DPSH_DEFUSRPWDHASH=\"$(PSH_DEFUSRPWDHASH)\"
-endif
+
+PSH_SYSEXECWL ?= ""
+CFLAGS += -DPSH_SYSEXECWL='"$(PSH_SYSEXECWL)"'
 
 PSH_ALLCOMMANDS = bind cat exec kill ls mem mkdir mount nc perf ping ps reboot runfile sync sysexec top touch
 PSH_COMMANDS ?= $(PSH_ALLCOMMANDS)

--- a/core/psh/psh.c
+++ b/core/psh/psh.c
@@ -1080,14 +1080,12 @@ static int psh_login(void)
 		}
 	}
 
-#ifdef PSH_DEFUSRPWDHASH
 	/* validate against defuser */
 	shadow = crypt(passwd, PSH_DEFUSRPWDHASH);
 	memset(passwd, '\0', maxlen);
 	if (shadow != NULL && strcmp(username, "defuser") == 0 && strcmp(shadow, PSH_DEFUSRPWDHASH) == 0)
 		return 1;
-#endif
-	memset(passwd, '\0', maxlen);
+
 	sleep(2);
 	return -1;
 }

--- a/core/psh/sysexec.c
+++ b/core/psh/sysexec.c
@@ -11,8 +11,10 @@
  * %LICENSE%
  */
 
+#include <ctype.h>
 #include <errno.h>
 #include <stdio.h>
+#include <string.h>
 #include <stdlib.h>
 
 #include <sys/threads.h>
@@ -25,12 +27,86 @@ void psh_sysexecinfo(void)
 }
 
 
+static int psh_sysexec_argmatch(const char *cmd, size_t cmdlen, int argc, const char **argv)
+{
+	int ii;
+	size_t len;
+	const char *currc = cmd, *nextc, *cmdend = cmd + cmdlen - 1;
+
+	for (ii = 0; ii < argc; ii++) {
+
+		if ((nextc = strchr(currc, ' ')) == NULL || nextc > cmdend)
+			nextc = cmdend;
+		len = nextc - currc;
+		if (strlen(argv[ii]) != len || memcmp(argv[ii], currc, len) != 0)
+			return -1;
+
+		if (nextc == cmdend || ii == (argc - 1))
+			break;
+
+		currc = nextc + 1;
+	}
+
+	if (nextc == cmdend && ii == (argc - 1))
+		return 1;
+	else
+		return -1;
+}
+
+
+static int psh_sysexec_checkcommand(int argc, const char **argv)
+{
+	int acc = -1, cmdlen;
+	static const char whitelist[] = PSH_SYSEXECWL;
+	const char *curr;
+	char cmdbuff[80] = "";
+	FILE *wlfile;
+
+	/* check against /etc/whitelist file */
+	if ((wlfile = fopen("/etc/whitelist", "r")) != NULL) {
+		acc = 0;
+		while (fgets(cmdbuff, sizeof(cmdbuff), wlfile) != NULL && acc != 1) {
+			if (isprint(cmdbuff[sizeof(cmdbuff) - 2])) {
+				while (isprint(fgetc(wlfile)))
+					;
+				memset(cmdbuff, 0, sizeof(cmdbuff));
+				continue;
+			}
+
+			cmdlen = strcspn(cmdbuff, "\n")  + 1;
+			if (psh_sysexec_argmatch(cmdbuff, cmdlen, argc, argv) > 0)
+				acc = 1;
+
+			memset(cmdbuff, 0, sizeof(cmdbuff));
+		}
+		fclose(wlfile);
+	}
+
+	/* check PSH_SYSEXECWL flag */
+	curr = whitelist;
+	while (*curr != '\0' && acc != 1) {
+		acc = 0;
+		cmdlen = strcspn(curr, ";") + 1;
+		if (psh_sysexec_argmatch(curr, cmdlen, argc, argv) > 0)
+			return 1;
+		else
+			curr = curr + cmdlen;
+	}
+
+	return (acc != 0);
+}
+
+
 int psh_sysexec(int argc, char **argv)
 {
 	int pid;
-
 	if (argc < 3) {
 		fprintf(stderr, "usage: %s map progname [args]...\n", argv[0]);
+		return -EINVAL;
+	}
+
+	if (psh_sysexec_checkcommand(argc, (const char **)argv) != 1) {
+		fprintf(stderr, "Unknown command!\n");
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
-added sysexec wildacrds. Allows execution only of predefined commands in /etc/wldcrds file (each command in newline)
or predefined in PSH_WILDCARDS enviroment variable (all comands in one line separated only by ';' sign)
If /etc/wldcrds file is not existing and no wildcards are specified in PSH_WILDCARDS then sysexec accepts all commands as usual
-removed #ifdef-s from psh login feature and assured that flags are defined in Makefile

JIRA: BES-148