### PR TITLE
psh: Fix coding style

### DIFF
--- a/core/psh/ls.c
+++ b/core/psh/ls.c
@@ -1,7 +1,7 @@
 /*
  * Phoenix-RTOS
  *
- * ls - lists files and directories, based on GNU implementation
+ * ls - lists files and directories
  *
  * Copyright 2017, 2018, 2020, 2021 Phoenix Systems
  * Author: Maciej Purski, Lukasz Kosinski, Mateusz Niewiadomski
@@ -406,7 +406,8 @@ static void psh_ls_free(void)
 }
 
 
-void psh_lsinfo(void){
+void psh_lsinfo(void)
+{
 	printf("  ls      - lists files in the namespace\n");
 }
 
@@ -421,7 +422,7 @@ int psh_ls(int argc, char **argv)
 	DIR *stream;
 
 	/* In case of ioctl fail set default window size */
-	if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &psh_ls_common.ws)) {
+	if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &psh_ls_common.ws) != 0) {
 		psh_ls_common.ws.ws_col = 80;
 		psh_ls_common.ws.ws_row = 25;
 	}

--- a/core/psh/mkdir.c
+++ b/core/psh/mkdir.c
@@ -17,7 +17,8 @@
 #include <sys/stat.h>
 
 
-void psh_mkdirinfo(void){
+void psh_mkdirinfo(void)
+{
 	printf("  mkdir   - creates directory\n");
 }
 

--- a/core/psh/perf.c
+++ b/core/psh/perf.c
@@ -94,7 +94,7 @@ int psh_perf(int argc, char **argv)
 			break;
 		}
 
-		fprintf(stderr, "perf: wrote %d/%ld bytes\n", bcount, bufsz);
+		fprintf(stderr, "perf: wrote %d/%zd bytes\n", bcount, bufsz);
 
 		usleep(sleeptime);
 		elapsed += sleeptime;

--- a/core/psh/psh-empties.c
+++ b/core/psh/psh-empties.c
@@ -25,7 +25,7 @@ void __attribute__((weak)) psh_bindinfo(void)
 
 int __attribute__((weak)) psh_bind(int argc, char **argv)
 {
-	fprintf(stderr,psh_common.unkncmd);
+	fprintf(stderr, psh_common.unkncmd);
 	return -ENOTSUP;
 }
 
@@ -38,7 +38,7 @@ void __attribute__((weak)) psh_catinfo(void)
 
 int __attribute__((weak)) psh_cat(int argc, char **argv)
 {
-	fprintf(stderr,psh_common.unkncmd);
+	fprintf(stderr, psh_common.unkncmd);
 	return -ENOTSUP;
 }
 
@@ -51,7 +51,7 @@ void __attribute__((weak)) psh_execinfo(void)
 
 int __attribute__((weak)) psh_exec(int argc, char **argv)
 {
-	fprintf(stderr,psh_common.unkncmd);
+	fprintf(stderr, psh_common.unkncmd);
 	return -ENOTSUP;
 }
 
@@ -64,7 +64,7 @@ void __attribute__((weak)) psh_helpinfo(void)
 
 int __attribute__((weak)) psh_help(void)
 {
-	fprintf(stderr,psh_common.unkncmd);
+	fprintf(stderr, psh_common.unkncmd);
 	return -ENOTSUP;
 }
 
@@ -77,7 +77,7 @@ void __attribute__((weak)) psh_killinfo(void)
 
 int __attribute__((weak)) psh_kill(int argc, char **argv)
 {
-	fprintf(stderr,psh_common.unkncmd);
+	fprintf(stderr, psh_common.unkncmd);
 	return -ENOTSUP;
 }
 
@@ -90,7 +90,7 @@ void __attribute__((weak)) psh_lsinfo(void)
 
 int __attribute__((weak)) psh_ls(int argc, char **argv)
 {
-	fprintf(stderr,psh_common.unkncmd);
+	fprintf(stderr, psh_common.unkncmd);
 	return -ENOTSUP;
 }
 
@@ -103,7 +103,7 @@ void __attribute__((weak)) psh_meminfo(void)
 
 int __attribute__((weak)) psh_mem(int argc, char **argv)
 {
-	fprintf(stderr,psh_common.unkncmd);
+	fprintf(stderr, psh_common.unkncmd);
 	return -ENOTSUP;
 }
 
@@ -116,7 +116,7 @@ void __attribute__((weak)) psh_mkdirinfo(void)
 
 int __attribute__((weak)) psh_mkdir(int argc, char **argv)
 {
-	fprintf(stderr,psh_common.unkncmd);
+	fprintf(stderr, psh_common.unkncmd);
 	return -ENOTSUP;
 }
 
@@ -129,7 +129,7 @@ void __attribute__((weak)) psh_mountinfo(void)
 
 int __attribute__((weak)) psh_mount(int argc, char **argv)
 {
-	fprintf(stderr,psh_common.unkncmd);
+	fprintf(stderr, psh_common.unkncmd);
 	return -ENOTSUP;
 }
 
@@ -142,7 +142,7 @@ void __attribute__((weak)) psh_ncinfo(void)
 
 int __attribute__((weak)) psh_nc(int argc, char **argv)
 {
-	fprintf(stderr,psh_common.unkncmd);
+	fprintf(stderr, psh_common.unkncmd);
 	return -ENOTSUP;
 }
 
@@ -155,7 +155,7 @@ void __attribute__((weak)) psh_perfinfo(void)
 
 int __attribute__((weak)) psh_perf(int argc, char **argv)
 {
-	fprintf(stderr,psh_common.unkncmd);
+	fprintf(stderr, psh_common.unkncmd);
 	return -ENOTSUP;
 }
 
@@ -180,7 +180,7 @@ void __attribute__((weak)) psh_psinfo(void)
 
 int __attribute__((weak)) psh_ps(int argc, char **argv)
 {
-	fprintf(stderr,psh_common.unkncmd);
+	fprintf(stderr, psh_common.unkncmd);
 	return -ENOTSUP;
 }
 
@@ -194,14 +194,14 @@ void __attribute__((weak)) psh_rebootinfo(void)
 
 int __attribute__((weak)) psh_reboot(int argc, char **argv)
 {
-	printf("Command not supported!");
+	fprintf(stderr, psh_common.unkncmd);
 	return -ENOTSUP;
 }
 
 
 int __attribute__((weak)) psh_runfile(int argc, char **argv)
 {
-	fprintf(stderr,psh_common.unkncmd);
+	fprintf(stderr, psh_common.unkncmd);
 	return -ENOTSUP;
 }
 
@@ -214,7 +214,7 @@ void __attribute__((weak)) psh_syncinfo(void)
 
 int __attribute__((weak)) psh_sync(int argc, char **argv)
 {
-	fprintf(stderr,psh_common.unkncmd);
+	fprintf(stderr, psh_common.unkncmd);
 	return -ENOTSUP;
 }
 
@@ -227,7 +227,7 @@ void __attribute__((weak)) psh_sysexecinfo(void)
 
 int __attribute__((weak)) psh_sysexec(int argc, char **argv)
 {
-	fprintf(stderr,psh_common.unkncmd);
+	fprintf(stderr, psh_common.unkncmd);
 	return -ENOTSUP;
 }
 
@@ -240,7 +240,7 @@ void __attribute__((weak)) psh_topinfo(void)
 
 int __attribute__((weak)) psh_top(int argc, char **argv)
 {
-	fprintf(stderr,psh_common.unkncmd);
+	fprintf(stderr, psh_common.unkncmd);
 	return -ENOTSUP;
 }
 
@@ -253,6 +253,6 @@ void __attribute__((weak)) psh_touchinfo(void)
 
 int __attribute__((weak)) psh_touch(int argc, char **argv)
 {
-	fprintf(stderr,psh_common.unkncmd);
+	fprintf(stderr, psh_common.unkncmd);
 	return -ENOTSUP;
 }

--- a/core/psh/top.c
+++ b/core/psh/top.c
@@ -247,7 +247,6 @@ void psh_topinfo(void)
 }
 
 
-
 int psh_top(int argc, char **argv)
 {
 	int c, err = 0, cmd = 0, itermode = 1, run = 1, ret = EOK;


### PR DESCRIPTION
Fix various minor coding style flaws, remove one redundant comment
and fix a printf format warning.