### PR TITLE
psh: sysexec whitelist support for `*` wildcard

### DIFF
--- a/core/psh/sysexec/sysexec.c
+++ b/core/psh/sysexec/sysexec.c
@@ -40,6 +40,8 @@ static int psh_sysexec_argmatch(const char *cmd, size_t cmdlen, int argc, const 
 		if ((nextc = strchr(currc, ' ')) == NULL || nextc > cmdend)
 			nextc = cmdend;
 		len = nextc - currc;
+		if (*currc == '*') /* "accept all" wildcard */
+			return 1;
 		if (strlen(argv[ii]) != len || memcmp(argv[ii], currc, len) != 0)
 			return -1;
 


### PR DESCRIPTION
 - Sysexec whitelist can contain `*` wildcard.
 - If command matches whitelist entry up to `*` it will be accepted (whatever follows).
 - `*` must be specified as standalone argument

JIRA: BES-159