### PR TITLE
psh/edit: fixed calculation of number of characters

### DIFF
--- a/core/psh/edit/edit.c
+++ b/core/psh/edit/edit.c
@@ -109,8 +109,8 @@ enum {
 static ssize_t term_print(const char *str)
 {
 	size_t len = 0;
-	while (str[len++] != '\0')
-		;
+	while (str[len] != '\0')
+		len++;
 
 	return write(STDOUT_FILENO, str, len);
 }


### PR DESCRIPTION
Now number of characters including `'\0'` is passed to `write()` function.
An alternative is to use the `strlen()` function.
