### PR TITLE
psh: remove `login` applet ambiguity

### DIFF
--- a/core/psh/Makefile
+++ b/core/psh/Makefile
@@ -21,14 +21,15 @@ LOCAL_LDFLAGS := -z stack-size=4096 -z noexecstack
 # TODO: search for dirs?
 PSH_ALLCOMMANDS := bind cat edit exec kill ls mem mkdir mount nc nslookup perf ping ps reboot runfile sync sysexec top touch
 PSH_COMMANDS ?= $(PSH_ALLCOMMANDS)
-PSH_APPLETS := pshapp help login $(filter $(PSH_ALLCOMMANDS), $(PSH_COMMANDS))
+PSH_APPLETS := pshapp help $(filter $(PSH_ALLCOMMANDS), $(PSH_COMMANDS))
 
 SRCS := $(foreach app, $(PSH_APPLETS), $(wildcard $(LOCAL_PATH)$(app)/*.c))
 
-# TODO: all applets?
+# Applets to create links:
+PSH_LINK_APPLETS := $(PSH_APPLETS) pshlogin
 # custom installation - automatically create rootfs hardlinks for all applets
 $(NAME)-install:
-	$(SIL)for applet in $(PSH_APPLETS); do \
+	$(SIL)for applet in $(PSH_LINK_APPLETS); do \
 		echo "LINK /bin/{psh -> $$applet}"; \
 		ln -f "$$PREFIX_ROOTFS/bin/psh" "$$PREFIX_ROOTFS/bin/$$applet"; \
 	done

--- a/core/psh/pshapp/pshapp.c
+++ b/core/psh/pshapp/pshapp.c
@@ -1008,7 +1008,7 @@ static int psh_run(int exitable)
 		return err;
 	}
 
-	/* Take terminal control */
+	/* Take terminal control - only interactive psh should take control */
 	if ((err = tcsetpgrp(STDIN_FILENO, pgrp)) < 0) {
 		fprintf(stderr, "psh: failed to take terminal control\n");
 		return err;
@@ -1149,27 +1149,12 @@ int psh_pshapp(int argc, char **argv)
 }
 
 
-int psh_pshapplogin(int argc, char **argv)
-{
-	const psh_appentry_t *loginapp = psh_findapp("login");
-	while (1) {
-		if (pshapp_common.isrunpsh != 0)
-			return -EACCES;
-		if ((loginapp == NULL || loginapp->run(argc, argv) == 1) && pshapp_common.isrunpsh == 0) {
-			pshapp_common.isrunpsh = 1;
-			psh_run(0);
-			pshapp_common.isrunpsh = 0;
-		}
-	}
-}
-
-
 void __attribute__((constructor)) pshapp_registerapp(void)
 {
-	static psh_appentry_t app_pshapp = {.name = "psh", .run = psh_pshapp, .info = NULL};
-	static psh_appentry_t app_pshappexit = {.name = "exit", .run = psh_pshappexit, .info = psh_pshappexitinfo};
-	static psh_appentry_t app_pshlogin = {.name = "pshlogin", .run = psh_pshapplogin, .info = NULL};
-	static psh_appentry_t app_pshhistory = {.name = "history", .run = psh_history, .info = psh_historyinfo};
+	static psh_appentry_t app_pshapp = { .name = "psh", .run = psh_pshapp, .info = NULL };
+	static psh_appentry_t app_pshappexit = { .name = "exit", .run = psh_pshappexit, .info = psh_pshappexitinfo };
+	static psh_appentry_t app_pshlogin = { .name = "pshlogin", .run = psh_pshapp, .info = NULL };
+	static psh_appentry_t app_pshhistory = { .name = "history", .run = psh_history, .info = psh_historyinfo };
 	
 	psh_registerapp(&app_pshapp);
 	psh_registerapp(&app_pshappexit);


### PR DESCRIPTION
Changes remove ambiguity between well known `login` command in UN*X like systems and current implementation of `login` applet in psh.
 - `login` applet renamed to `auth` and moved to pshapp directory
 - `pshlogin` moved to separate directory to allow execution, testing and excluding from building
 -  trying to start second interactive psh (`pshapp`) under one psh process returns a message (either called from `psh` or `pshlogin` command)

JIRA: BES-164