### PR TITLE
psh: fix exec environment resetting

### DIFF
--- a/core/psh/exec/exec.c
+++ b/core/psh/exec/exec.c
@@ -34,7 +34,7 @@ int psh_exec(int argc, char **argv)
 		return -EINVAL;
 	}
 
-	switch (err = execve(argv[1], argv + 1, NULL)) {
+	switch (err = execv(argv[1], argv + 1)) {
 	case EOK:
 		break;
 

--- a/core/psh/pshapp/pshapp.c
+++ b/core/psh/pshapp/pshapp.c
@@ -866,7 +866,7 @@ static int psh_runscript(char *path)
 					break;
 				}
 				else if (!pid) {
-					execve(argv[0], argv, NULL);
+					execv(argv[0], argv);
 					fprintf(stderr, "psh: exec failed in line %d\n", i);
 					_psh_exit(EXIT_FAILURE);
 				}

--- a/core/psh/runfile/runfile.c
+++ b/core/psh/runfile/runfile.c
@@ -43,7 +43,7 @@ int psh_runfile(int argc, char **argv)
 		tcsetpgrp(STDIN_FILENO, pid);
 
 		/* Execute the file */
-		execve(argv[0], argv, NULL);
+		execv(argv[0], argv);
 
 		switch (errno) {
 		case EIO:


### PR DESCRIPTION
Child processes should inherit PSH environment (especially PWD).

JIRA: RTOS-36