### PR TITLE
psh: ps: sort by PID by default

### DIFF
--- a/core/psh/ps/ps.c
+++ b/core/psh/ps/ps.c
@@ -156,9 +156,9 @@ static int psh_ps(int argc, char **argv)
 		printf("%6s ", buff);
 
 		if (!threads)
-			printf("%3u %.*s\n", info[i].tid, (fullcmd ? sizeof(info[i].name) : 28), info[i].name);
+			printf("%3u %.*s\n", info[i].tid, (int)(fullcmd ? sizeof(info[i].name) : 28), info[i].name);
 		else
-			printf("%.*s\n", (fullcmd ? sizeof(info[i].name) : 32), info[i].name);
+			printf("%.*s\n", (int)(fullcmd ? sizeof(info[i].name) : 32), info[i].name);
 	}
 
 	free(info);

--- a/core/psh/ps/ps.c
+++ b/core/psh/ps/ps.c
@@ -56,15 +56,15 @@ static void usage(const char *progname)
 	printf("    -f    Show full commandline\n");
 	printf("    -h    Show help instead\n");
 	printf("\nSorting:\n");
-	printf("    -c    Sort by current CPU usage [default]\n");
+	printf("    -c    Sort by current CPU usage\n");
 	printf("    -n    Sort by name\n");
-	printf("    -p    Sort by PID\n");
+	printf("    -p    Sort by PID [default]\n");
 }
 
 
 static int psh_ps(int argc, char **argv)
 {
-	int (*cmp)(const void *, const void *) = psh_ps_cmpcpu;
+	int (*cmp)(const void *, const void *) = psh_ps_cmppid;
 	int c, tcnt, i, j, n = 32;
 	unsigned int threads = 0, fullcmd = 0;
 	threadinfo_t *info, *rinfo;


### PR DESCRIPTION
Rationale: 
 - we have `top` for watching the CPU usage.
 - `ps` sorts by PID in BSD and Linux by default so user expects that

JIRA: RTOS-35