### PR TITLE
psh: stack size change

### DIFF
--- a/core/psh/Makefile
+++ b/core/psh/Makefile
@@ -16,7 +16,7 @@ PSH_SYSEXECWL ?=
 
 LOCAL_CFLAGS := -DPSH_DEFUSRPWDHASH=\"$(PSH_DEFUSRPWDHASH)\"
 LOCAL_CFLAGS += -DPSH_SYSEXECWL='"$(PSH_SYSEXECWL)"'
-LOCAL_LDFLAGS += -z stack-size=4096 -z noexecstack
+LOCAL_LDFLAGS := -z stack-size=4096 -z noexecstack
 
 # TODO: search for dirs?
 PSH_ALLCOMMANDS := bind cat edit exec kill ls mem mkdir mount nc nslookup perf ping ps reboot runfile sync sysexec top touch

--- a/core/psh/Makefile
+++ b/core/psh/Makefile
@@ -16,6 +16,7 @@ PSH_SYSEXECWL ?=
 
 LOCAL_CFLAGS := -DPSH_DEFUSRPWDHASH=\"$(PSH_DEFUSRPWDHASH)\"
 LOCAL_CFLAGS += -DPSH_SYSEXECWL='"$(PSH_SYSEXECWL)"'
+LOCAL_LDFLAGS += -z stack-size=4096 -z noexecstack
 
 # TODO: search for dirs?
 PSH_ALLCOMMANDS := bind cat edit exec kill ls mem mkdir mount nc nslookup perf ping ps reboot runfile sync sysexec top touch


### PR DESCRIPTION
JIRA: BES-167

## Description
Linker flag `stack-size` added to psh Makefile to increase its stack size on no MMU targets

## Motivation and Context
Psh is very important Phoenix-RTOS program and as a user input/output program should have bigger stack than default one.
Also fixes the bug that cashes the imxrt1064 when `ls -l` is executed in psh. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic, imxrt1064.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
