### PR TITLE
psh: fix hanging after second execution

### DIFF
--- a/core/psh/pshapp/pshapp.c
+++ b/core/psh/pshapp/pshapp.c
@@ -983,8 +983,9 @@ static int psh_run(int exitable)
 
 	/* Wait till we run in foreground */
 	if (tcgetpgrp(STDIN_FILENO) != -1) {
-		while ((pgrp = getpgrp()) != tcgetpgrp(STDIN_FILENO))
-			kill(-pgrp, SIGTTIN);
+		while ((pgrp = tcgetpgrp(STDIN_FILENO)) != getpgrp())
+			if (kill(-pgrp, SIGTTIN) == 0)
+				break;
 	}
 
 	/* Set signal handlers */

--- a/core/psh/sysexec/sysexec.c
+++ b/core/psh/sysexec/sysexec.c
@@ -16,6 +16,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
+#include <termios.h>
 
 #include <sys/threads.h>
 #include <sys/types.h>
@@ -118,6 +120,8 @@ int psh_sysexec(int argc, char **argv)
 
 	if (pid > 0) {
 		waitpid(pid, NULL, 0);
+		/* Take back terminal control */
+		tcsetpgrp(STDIN_FILENO, getpgrp());
 		return EOK;
 	}
 


### PR DESCRIPTION
JIRA: BES-170

<!--- Provide a general summary of your changes in the Title above -->

## Description
 - added break after sending SIGTTIN in `pshapp`
 - sysexec regains control over terminal

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Psh was left hanging after second execution both from `ash` and on imxrt106x using sysexec.
https://github.com/phoenix-rtos/phoenix-rtos-utils/issues/47

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32 (both in `ash` and in `psh`), imxrt1064

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
