### PR TITLE
psh/mem: Fix warning message

### DIFF
--- a/core/psh/mem/mem.c
+++ b/core/psh/mem/mem.c
@@ -82,7 +82,7 @@ static void psh_mem_procprint(entryinfo_t *e, int mapsz)
 		else if (e->object == OBJECT_MEMORY)
 			printf("  %s", "mem");
 		else
-			printf("  %d.%llu", e->oid.port, e->oid.id);
+			printf("  %d.%llu", e->oid.port, (unsigned long long)e->oid.id);
 
 		if (e->object != OBJECT_ANONYMOUS && e->anonsz != ~0)
 			printf("/(%zuKB)", e->anonsz / 1024);


### PR DESCRIPTION
JIRA: ISC-118

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
On some platform psh/mem.c generates warning while build.

> format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'id_t' {aka 'unsigned int'} [-Wformat=]

Basing on example CI build https://github.com/phoenix-rtos/phoenix-rtos-utils/actions/runs/978986094 it affects all armv7m platfotm
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #68 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7m4-stm32l4x6 (build only).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
