### PR TITLE
psd: bad blocks array fix

### DIFF
--- a/core/psd/imx6ull/flashmng.c
+++ b/core/psd/imx6ull/flashmng.c
@@ -172,13 +172,21 @@ int flashmng_checkRange(oid_t oid, int start, int end, dbbt_t **dbbt)
 	int i, ret = 0;
 	int bad = 0;
 	int err = 0;
-	uint32_t bbt[256] = { 0 };
+	uint32_t *bbt;
 	uint32_t bbtn = 0;
 	int dbbtsz;
-	void *raw_data = malloc(2 * FLASH_PAGE_SIZE);
+	void *raw_data;
 
+	bbt = calloc(BB_MAX, sizeof(uint32_t));
+	if (bbt == NULL) {
+		printf("Failed to map pages from OC RAM\n");
+		return -1;
+	}
+
+	raw_data = malloc(2 * FLASH_PAGE_SIZE);
 	if (raw_data == NULL) {
 		printf("Failed to map pages from OC RAM\n");
+		free(bbt);
 		return -1;
 	}
 
@@ -219,6 +227,7 @@ int flashmng_checkRange(oid_t oid, int start, int end, dbbt_t **dbbt)
 		(*dbbt)->entries_num = bbtn;
 	}
 
+	free(bbt);
 	free(raw_data);
 	return (bbtn >= BB_MAX);
 }


### PR DESCRIPTION
JIRA: RTOS-67

<!--- Provide a general summary of your changes in the Title above -->

## Description
Allocate bad blocks array on the heap.
<!--- Describe your changes shortly -->

## Motivation and Context
Bad blocks array was probably overflowing stack on imx6ull.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imx6ull).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
