### PR TITLE
imx6ull-psd: rewrite

### DIFF
--- a/core/psd/imx6ull/bcb.h
+++ b/core/psd/imx6ull/bcb.h
@@ -19,6 +19,8 @@
 #include <stdio.h>
 #include <stdint.h>
 
+#include <imx6ull-flashsrv.h>
+
 #define BB_MAX	256
 
 #define BCB_CNT 4
@@ -97,9 +99,9 @@ typedef struct _dbbt_t {
 } dbbt_t;
 
 
-int fcb_flash(oid_t oid, fcb_t *fcb_ret);
+int fcb_flash(oid_t oid, const flashsrv_info_t *info);
 
-int dbbt_flash(oid_t oid, FILE *f, dbbt_t *dbbt);
+int dbbt_flash(oid_t oid, int fd, dbbt_t *dbbt, const flashsrv_info_t *info);
 
 int dbbt_block_is_bad(dbbt_t *dbbt, uint32_t block_num);
 

--- a/core/psd/imx6ull/flashmng.h
+++ b/core/psd/imx6ull/flashmng.h
@@ -17,22 +17,29 @@
 #include <sys/msg.h>
 #include <stdint.h>
 
+#include <imx6ull-flashsrv.h>
 #include "bcb.h"
 
 
-int flashmng_readraw(oid_t oid, uint32_t paddr, void *data, int size);
+int flashmng_readraw(oid_t oid, uint32_t addr, void *data, int size);
 
 
-int flashmng_writedev(oid_t oid, uint32_t paddr, void *data, int size, int type);
+int flashmng_writedev(oid_t oid, uint32_t addr, void *data, int size, int type);
 
 
-int flashmng_eraseBlock(oid_t oid, int start, int end, int chip_erase);
+int flashmng_eraseBlocks(oid_t oid, unsigned int start, unsigned int size);
 
 
 int flashmng_getAttr(int type, offs_t* val, oid_t oid);
 
 
-int flashmng_checkRange(oid_t oid, int start, int end, dbbt_t **dbbt);
+int flashmng_checkRange(oid_t oid, unsigned int start, unsigned int size, dbbt_t **dbbt);
 
 
-int flashmng_cleanMarkers(oid_t oid, int start, int end);
+int flashmng_cleanMarkers(oid_t oid, unsigned int start, unsigned int size);
+
+
+int flashmng_getInfo(oid_t oid, flashsrv_info_t *info);
+
+
+int flashmng_isBadBlock(oid_t oid, uint32_t addr);


### PR DESCRIPTION
## Description

 - use direct FDs instead of buffered FILE*
 - obtain NAND flash params dynamically
 - generate FCB based on obtained NAND params
 - remove obsolete chip functions (use /dev/flash0 file directly)
 - fix badblock detection and management
 - unionize flashmng interface
 - remove unnecessary mmaped memory
 - describe FUSEs blown

## Motivation and Context
JIRA: DTR-88


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imx6ull`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-devices/pull/121
