### PR TITLE
psh: change stop-gap so it does not produce warnings

### DIFF
--- a/core/psh/pshapp/pshapp.c
+++ b/core/psh/pshapp/pshapp.c
@@ -567,9 +567,8 @@ static int psh_readcmd(struct termios *orig, psh_hist_t *cmdhist, char **cmd)
 					psh_movecursor(n + m + sizeof(PROMPT) - 1, -m);
 				}
 			}
-#if 0 /* FIXME: tab-completion currently breaks psh, disable it until it will be fixed */
 			/* TAB => autocomplete paths */
-			else if (c == '\t') {
+			else if (c == '\t' && 0) { /* FIXME: tab-completion currently breaks psh, disable it until it will be fixed */
 				nfiles = err = 0;
 				path = (hp != cmdhist->he) ? cmdhist->entries[hp].cmd : *cmd;
 				for (i = n; i && (path[i - 1] != ' ') && (path[i - 1] != '\0'); i--);
@@ -640,7 +639,6 @@ static int psh_readcmd(struct termios *orig, psh_hist_t *cmdhist, char **cmd)
 						break;
 				}
 			}
-#endif
 			/* FF => clear screen */
 			else if (c == '\014') {
 				write(STDOUT_FILENO, "\033[f", 3);


### PR DESCRIPTION
JIRA: PD-160

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Change stopgap of psh autocompletion so it does not produce warnings. Commit valid till https://github.com/phoenix-rtos/phoenix-rtos-utils/pull/78 will be merge

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Psh produces warnings as there is a stopgap for psh autocompletion feature

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
