### PR TITLE
psd: fix data transfer condition in psd_writeFile()

### DIFF
--- a/core/psd/imx6ull/psd.c
+++ b/core/psd/imx6ull/psd.c
@@ -361,10 +361,9 @@ static int psd_writeFile(sdp_cmd_t *cmd)
 	for (writesz = 0; !err && (writesz < cmd->datasz); writesz += buffOffset) {
 
 		memset(psd_common.buff, 0xff, psd_common.flash.writesz);
-		res = HID_REPORT_2_SIZE - 1;
 		buffOffset = 0;
 
-		while ((buffOffset < psd_common.flash.writesz) && (res == (HID_REPORT_2_SIZE - 1))) {
+		while ((buffOffset < psd_common.flash.writesz) && (writesz + buffOffset < cmd->datasz)) {
 			if ((res = sdp_recv(1, psd_common.rcvBuff, HID_REPORT_2_SIZE, &outdata)) < 0 ) {
 				err = -eReport2;
 				break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
The last packet received with sdp_recv() can have size equal to HID_REPORT_2_SIZE - 1 (1024 bytes), which currently causes psd to wait for another packet if we haven't filled up full flash page yet. Use file size comparison for last packet detection.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
psd hangs if last packet size equals to 1024 and we haven't filled up full flash page.
[JIRA: RTOS-70](https://jira.phoenix-rtos.com/browse/RTOS-70)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
