### PR TITLE
psd: force BootROM to not use DBBT and check for badblock markers instead

### DIFF
--- a/core/psd/imx6ull/bcb.c
+++ b/core/psd/imx6ull/bcb.c
@@ -63,6 +63,12 @@ int dbbt_block_is_bad(dbbt_t *dbbt, uint32_t block_num)
 }
 
 
+/* FIXME: current DBBT implementation isn't recognized as a valid one by the BootROM */
+/* The following DBBT test should pass (it currently fails): */
+/* 1. Enable DBBT usage in FCB by setting dbbt_start = 0x100 and disable_bbm_search = 1 */
+/* 2. Add FW1 block (8th block) to BBT in flashmng_checkRange() */
+/* 3. Flash FW1 onto the next block (9th block) */
+/* 4. BootROM should detect FW1 block as a badblock and load firmware from the next block */
 int dbbt_flash(oid_t oid, int fd, dbbt_t *dbbt, const flashsrv_info_t *info)
 {
 	unsigned int i, dbbt_failed = 0;
@@ -134,8 +140,8 @@ void fcb_init(fcb_t *fcb, const flashsrv_info_t *info)
 	fcb->fw2_start = 24 * 64;
 	fcb->fw1_size = 0x1;
 	fcb->fw2_size = 0x1;
-	fcb->dbbt_start = 0x100;
-	fcb->bbm_offset = 0x1000; /* FIXME */
+	fcb->dbbt_start = 0x0; /* don't load DBBT, use badblock markers only */
+	fcb->bbm_offset = 0x1000;
 	fcb->bbm_start = 0x0;
 	fcb->bbm_phys_offset = 0x1000;
 	fcb->bch_type = 0x0;
@@ -149,7 +155,7 @@ void fcb_init(fcb_t *fcb, const flashsrv_info_t *info)
 	fcb->busy_timeout = 0xffff;
 	fcb->bbm_disabled = 1; /* disable badblock marker swapping */
 	fcb->bbm_spare_offset = 0;
-	fcb->disable_bbm_search = 1; /* use only DBBT when loading firmware, TODO: maybe bad block markers instead? */
+	fcb->disable_bbm_search = 0; /* use badblock markers when loading firmware */
 
 	fcb->checksum = bcb_checksum(((uint8_t *)fcb) + 4, sizeof(fcb_t) - 4);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Changed FCB configuration forcing BootROM to use badblock markers instead of DBBT.
If firmware happens to lie on a badblock, BootROM will try load it from the next block.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: DTR-95](https://jira.phoenix-rtos.com/browse/DTR-95)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
