### PR TITLE
psh: fix ls and TAB autocompletion not resolving directory symlinks - use stat() instead of lstat()

### DIFF
--- a/core/psh/ls/ls.c
+++ b/core/psh/ls/ls.c
@@ -499,23 +499,13 @@ int psh_ls(int argc, char **argv)
 
 	/* Try to stat all the given paths */
 	for (i = 0; i < npaths; i++) {
-		c = strlen(paths[i]);
-
-		if (paths[i][c - 1] == '/') {
-			if (c > 1)
-				paths[i][c - 1] = '\0';
-
-			if ((ret = lstat(paths[i], &psh_ls_common.files[nfiles].stat)) < 0) {
-				fprintf(stderr, "ls: can't access %s/: no such file or directory\n", paths[i]);
-				continue;
-			}
-			else if (!S_ISDIR(psh_ls_common.files[nfiles].stat.st_mode)) {
-				fprintf(stderr, "ls: can't access %s/: not a directory\n", paths[i]);
-				continue;
-			}
-		}
-		else if ((ret = lstat(paths[i], &psh_ls_common.files[nfiles].stat)) < 0) {
+		if ((ret = stat(paths[i], &psh_ls_common.files[nfiles].stat)) < 0) {
 			fprintf(stderr, "ls: can't access %s: no such file or directory\n", paths[i]);
+			continue;
+		}
+
+		if ((paths[i][strlen(paths[i]) - 1] == '/') && !S_ISDIR(psh_ls_common.files[nfiles].stat.st_mode)) {
+			fprintf(stderr, "ls: can't access %s: not a directory\n", paths[i]);
 			continue;
 		}
 

--- a/core/psh/pshapp/pshapp.c
+++ b/core/psh/pshapp/pshapp.c
@@ -305,7 +305,7 @@ static int psh_completepath(char *dir, char *base, char ***files)
 	size_t i, size = 32, dlen = strlen(dir), blen = strlen(base);
 	int nfiles = 0, err = EOK;
 	char *path, **rfiles;
-	struct stat stat;
+	struct stat st;
 	DIR *stream;
 
 	*files = NULL;
@@ -339,8 +339,8 @@ static int psh_completepath(char *dir, char *base, char ***files)
 			memcpy(path, dir, dlen);
 			strcpy(path + dlen, stream->dirent->d_name);
 
-			if ((err = lstat(path, &stat)) < 0) {
-				fprintf(stderr, "\r\npsh: can't stat file %s\r\n", path);
+			if ((err = stat(path, &st)) < 0) {
+				fprintf(stderr, "\r\npsh: can't stat %s\r\n", path);
 				free(path);
 				break;
 			}
@@ -362,7 +362,7 @@ static int psh_completepath(char *dir, char *base, char ***files)
 				break;
 			}
 			memcpy((*files)[nfiles], stream->dirent->d_name, stream->dirent->d_namlen);
-			(*files)[nfiles][stream->dirent->d_namlen] = (S_ISDIR(stat.st_mode)) ? '/' : ' ';
+			(*files)[nfiles][stream->dirent->d_namlen] = (S_ISDIR(st.st_mode)) ? '/' : ' ';
 			(*files)[nfiles][stream->dirent->d_namlen + 1] = '\0';
 			nfiles++;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Changed `lstat()` usage to `stat()` in ls and TAB autocompletion. `lstat()` doesn't resolve symlinks.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
phoenix-rtos/phoenix-rtos-project#180
[JIRA: RTOS-86](https://jira.phoenix-rtos.com/browse/RTOS-86)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
