### PR TITLE
psh: return codes and isrunpsh logic fix

### DIFF
--- a/core/psh/psh.h
+++ b/core/psh/psh.h
@@ -28,6 +28,7 @@ typedef struct {
 	volatile unsigned char sigint;  /* Received SIGINT */
 	volatile unsigned char sigquit; /* Received SIGQUIT */
 	volatile unsigned char sigstop; /* Received SIGTSTP */
+	pid_t tcpid;
 } psh_common_t;
 
 

--- a/core/psh/pshapp/auth.c
+++ b/core/psh/pshapp/auth.c
@@ -111,24 +111,24 @@ static int psh_auth(int argc, char **argv)
 	if (isatty(STDOUT_FILENO) == 0) {
 		sleep(1);
 		fprintf(stderr, "psh: unable to login, not a tty\n");
-		return ENOTTY;
+		return -ENOTTY;
 	}
 
 	/* Get login from user */
 	if (psh_authcredentget(username, 0, maxlen) == -EINTR)
-		return EINTR;
+		return -EINTR;
 	userdata = getpwnam(username);
 
 	/* Get password from user */
 	if (psh_authcredentget(passwd, 1, maxlen) == -EINTR)
-		return EINTR;
+		return -EINTR;
 
 	/* validate against /etc/passwd */
 	if (userdata != NULL) {
 		shadow = crypt(passwd, userdata->pw_passwd);
 		if (shadow != NULL && strcmp(userdata->pw_passwd, shadow) == 0) {
 			memset(passwd, '\0', maxlen);
-			return 0;
+			return EOK;
 		}
 	}
 
@@ -136,10 +136,10 @@ static int psh_auth(int argc, char **argv)
 	shadow = crypt(passwd, PSH_DEFUSRPWDHASH);
 	memset(passwd, '\0', maxlen);
 	if (shadow != NULL && strcmp(username, "defuser") == 0 && strcmp(shadow, PSH_DEFUSRPWDHASH) == 0)
-		return 0;
+		return EOK;
 
 	sleep(2);
-	return 1;
+	return -EACCES;
 }
 
 

--- a/core/psh/reboot/reboot.c
+++ b/core/psh/reboot/reboot.c
@@ -47,7 +47,7 @@ int psh_reboot(int argc, char **argv)
 
 	if (reboot(magic) < 0) {
 		fprintf(stderr, "reboot: failed to restart the machine\n");
-		return -1;
+		return -EPERM;
 	}
 
 	return EOK;

--- a/core/psh/uptime/uptime.c
+++ b/core/psh/uptime/uptime.c
@@ -30,7 +30,7 @@ int psh_uptime(int argc, char **argv)
 	int rv = clock_gettime(CLOCK_MONOTONIC_RAW, &tp);
 	if (rv < 0) {
 		fprintf(stderr, "uptime: failed to get time\n");
-		return -1;
+		return -EINVAL;
 	}
 	printf("%jd\n", (intmax_t)tp.tv_sec);
 	return EOK;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This PR changes two things:
 - removes `isrunpsh` logic
 -  psh determines its interactivity by checking `cmdhist` pointer initialization
 - makes `psh` return execution status in following manner:
   - psh returns `0` if no error occured
   - psh returns `1` and sets `errno` if error occured

Also i checked through return codes of some psh applets and unify their error return value to be negative as to conform with logic:
 - inside psh negative value means error, 0 means success
 - outside psh 1 means error, 0 means success

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As for now psh returns `EOK` (`0`) no matter what happens during its execution. This together with `isrunpsh` made it quite hard to get any information about psh execution. By getting rid of `isrunpsh` variable `psh` relies now only on important pointer `cmdhist` initialization to properly execute under `psh` and `pshlogin` name under new process.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic, imxrt1064).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
