### PR TITLE
gh-actions: add mail notification, when there is some problem not caused by user

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
   build:
     name: build image
     runs-on: ubuntu-latest
+    outputs:
+      build_result: ${{ steps.build.outcome }}
     strategy:
       matrix:
         target: ['armv7a7-imx6ull', 'armv7a9-zynq7000', 'armv7m7-imxrt106x', 'armv7m7-imxrt117x', 'armv7m4-stm32l4x6', 'host-pc', 'ia32-generic', 'riscv64-spike', 'riscv64-virt']
@@ -44,6 +46,7 @@ jobs:
 
       # step 3: use our custom action to build the project
       - name: Build
+        id: build
         uses: ./.github/actions/phoenix-build
         with:
           target: ${{ matrix.target }}
@@ -72,6 +75,8 @@ jobs:
     needs: build
     name: run tests on emulators
     runs-on: ubuntu-latest
+    outputs:
+      runner_result: ${{ steps.runner.outcome }}
     strategy:
       matrix:
         target: ['host-pc', 'ia32-generic']
@@ -83,7 +88,6 @@ jobs:
           repository: phoenix-rtos/phoenix-rtos-project
           submodules: recursive
 
-      # step 2: update the submodule
       - name: Update submodule ${{ github.event.repository.name }}
         working-directory: ${{ github.event.repository.name }}
         run: |
@@ -101,6 +105,7 @@ jobs:
         run: tar -xvf ../rootfs-${{ matrix.target }}.tar
 
       - name: Test runner
+        id: runner
         uses: ./.github/actions/phoenix-runner
         with:
           target: ${{ matrix.target }}
@@ -109,6 +114,8 @@ jobs:
     needs: build
     name: run tests on hardware
     runs-on: ${{ matrix.target }}
+    outputs:
+      runner_result: ${{ steps.runner.outcome }}
     strategy:
       matrix:
         target: ['armv7m7-imxrt106x']
@@ -120,7 +127,6 @@ jobs:
           repository: phoenix-rtos/phoenix-rtos-project
           submodules: recursive
 
-      # step 2: update the submodule
       - name: Update submodule ${{ github.event.repository.name }}
         working-directory: ${{ github.event.repository.name }}
         run: |
@@ -138,5 +144,32 @@ jobs:
         run: tar -xvf ../rootfs-${{ matrix.target }}.tar
 
       - name: Test runner
+        id: runner
         run: |
           python3 ./phoenix-rtos-tests/runner.py -T${{ matrix.target }}
+
+  mail-notification:
+    if: ${{ failure() }}
+    needs: ['build', 'test-emu', 'test-hw']
+    name: notify ci team using e-mail
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send mail
+        # If there is some failure, not caused by build step or test runner step send mail
+        if: >-
+          ${{ needs.build.outputs.build_result != 'failure'
+          && needs.test-emu.outputs.runner_result != 'failure'
+          && needs.test-hw.outputs.runner_result != 'failure' }}
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          username: ${{ secrets.CI_BOT_EMAIL_USERNAME }}
+          password: ${{ secrets.CI_BOT_EMAIL_PASSWORD }}
+          subject: Github Actions Warning
+          to: ci@phoenix-rtos.com
+          # Required sender full name (address can be skipped):
+          from: Continuous Integration Bot
+          # Optional whether this connection use TLS (default is true if server_port is 465)
+          secure: true
+          body: There is some problem with GH Actions. https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}


### PR DESCRIPTION
JIRA: CI-87

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Mails are sent to continuous integration team, when some fails occur in github-actions workflows (steps other than build in Build job and runner step in tests job).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There was no information for ci team about fails not caused by user in gh-actions ci workflows

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
