### PR TITLE
psh: make uptime more human readable

### DIFF
--- a/core/psh/uptime/uptime.c
+++ b/core/psh/uptime/uptime.c
@@ -4,7 +4,7 @@
  * uptime - prints how long the system has been running
  *
  * Copyright 2021 Phoenix Systems
- * Author: Ziemowit Leszczynski
+ * Author: Ziemowit Leszczynski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -27,12 +27,37 @@ void psh_uptimeinfo(void)
 int psh_uptime(int argc, char **argv)
 {
 	struct timespec tp;
-	int rv = clock_gettime(CLOCK_MONOTONIC_RAW, &tp);
+	intmax_t days, seconds;
+	int minutes, hours, rv;
+
+	rv = clock_gettime(CLOCK_MONOTONIC_RAW, &tp);
 	if (rv < 0) {
 		fprintf(stderr, "uptime: failed to get time\n");
 		return -EINVAL;
 	}
-	printf("%jd\n", (intmax_t)tp.tv_sec);
+
+	seconds = tp.tv_sec;
+
+	if (argc == 1 && seconds >= 0) {
+		days = seconds / 86400;
+		seconds %= 86400;
+		hours = seconds / 3600;
+		seconds %= 3600;
+		minutes = seconds / 60;
+		seconds %= 60;
+
+		printf("up ");
+
+		if (days > 0)
+			printf("%jd day%s and ", days, days == 1 ? "" : "s");
+
+		printf("%02d:%02d:%02d\n", hours, minutes, (int)seconds);
+	}
+	else {
+		printf("%jd\n", seconds);
+	}
+
+
 	return EOK;
 }
 


### PR DESCRIPTION
JIRA: RTOS-108
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Make uptime return by default more human readable information like
```
up 1024 days and 23:59:59
```
, instead of just displaying only the seconds since booting up.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1176, imxrt1064, ia32-qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
