### PR TITLE
pshlogin: add cmdhist dereferencing at exit

### DIFF
--- a/core/psh/pshapp/pshapp.c
+++ b/core/psh/pshapp/pshapp.c
@@ -1138,6 +1138,7 @@ static int psh_run(int exitable)
 		free(cmdhist->entries[cmdhist->hb].cmd);
 
 	free(cmdhist);
+	pshapp_common.cmdhist = NULL;
 
 	return err;
 }


### PR DESCRIPTION


JIRA: PD-109

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
The psh was missing a functionality where on exit it did not `NULL` the `pshapp_common.cmdhist` variablle but later check for its nullability on reentry after `ctrl+d` or `exit` command
Stopgap for no reantry to pshlogin as **Healthmon** is going to be implemented soon

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1064, ia32-generic).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
