### PR TITLE
psd: Change libusbclass to libusb

### DIFF
--- a/core/psd/Makefile
+++ b/core/psd/Makefile
@@ -7,7 +7,7 @@
 NAME := psd
 LOCAL_PATH = $(call my-dir)
 LOCAL_SRCS := common/sdp.c
-LIBS := libusbclass libusbclient
+LIBS := libusb libusbclient
 LOCAL_INSTALL_PATH := /sbin
 
 ifneq (, $(findstring imxrt, $(TARGET)))


### PR DESCRIPTION
JIRA: RTOS-21

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Change the name of usb library.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It is needed in order to build phoenix-rtos-utils once the phoenix-rtos-usb PR: https://github.com/phoenix-rtos/phoenix-rtos-usb/pull/11 gets merged.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1064).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (https://github.com/phoenix-rtos/phoenix-rtos-usb/pull/11).
- [ ] I will merge this PR by myself when appropriate.
