### PR TITLE
psh: reenable option to target-specific reboot operation

### DIFF
--- a/core/psh/reboot/reboot.c
+++ b/core/psh/reboot/reboot.c
@@ -20,17 +20,16 @@
 #include "../psh.h"
 
 
-void psh_rebootinfo(void)
+static void psh_rebootinfo(void)
 {
 	printf("restarts the machine");
 }
 
 
-int psh_reboot(int argc, char **argv)
+static int psh_reboot(int argc, char **argv)
 {
 	int c, magic = PHOENIX_REBOOT_MAGIC;
 
-#ifdef TARGET_IMX6ULL
 	while ((c = getopt(argc, argv, "s")) != -1) {
 		switch (c) {
 		case 's':
@@ -41,9 +40,6 @@ int psh_reboot(int argc, char **argv)
 			return EOK;
 		}
 	}
-#else
-	(void)c;
-#endif
 
 	if (reboot(magic) < 0) {
 		fprintf(stderr, "reboot: failed to restart the machine\n");


### PR DESCRIPTION
## Description

Currently implemented only for imx6ull - booting from secondary NAND
image.


## Motivation and Context
JIRA: DTR-181

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
