### PR TITLE
Nandwrite enhancements

### DIFF
--- a/core/nandtool/flashmng.h
+++ b/core/nandtool/flashmng.h
@@ -30,4 +30,8 @@ int flashmng_checkbad(oid_t oid);
 int flashmng_isbad(oid_t oid, unsigned int block);
 
 
+/* write JFFS2 clean block markers */
+int flashmng_cleanMarkers(oid_t oid, unsigned int start, unsigned int size);
+
+
 flashsrv_info_t *flashmng_info(oid_t oid);

--- a/core/nandtool/nandtool.c
+++ b/core/nandtool/nandtool.c
@@ -119,6 +119,7 @@ static int nandtool_flash(const char *path, unsigned int start, int raw)
 			break;
 
 		printf("\rFlashing %s completed!\n", path);
+		err = 0;
 	} while (0);
 
 	free(buff);
@@ -214,19 +215,20 @@ int main(int argc, char **argv)
 
 	if ((err = lookup(dev, NULL, &nandtool_common.oid)) < 0) {
 		fprintf(stderr, "nandtool: failed to lookup device (%s), err: %d\n", dev, err);
-		return err;
+		return 1;
 	}
 
 	if ((err = open(dev, O_RDWR)) < 0) {
 		fprintf(stderr, "nandtool: failed to open device (%s), err: %d\n", dev, err);
-		return err;
+		return 1;
 	}
 	nandtool_common.fd = err;
 
 	if ((nandtool_common.info = flashmng_info(nandtool_common.oid)) == NULL) {
 		err = -EFAULT;
 		fprintf(stderr, "nandtool: failed to get device info (%s), err: %d\n", dev, err);
-		return err;
+		close(nandtool_common.fd);
+		return 1;
 	}
 
 	do {
@@ -242,5 +244,5 @@ int main(int argc, char **argv)
 
 	close(nandtool_common.fd);
 
-	return err;
+	return (err < 0) ? 1 : 0;
 }

--- a/core/nandtool/nandtool.c
+++ b/core/nandtool/nandtool.c
@@ -211,15 +211,22 @@ int main(int argc, char **argv)
 		nandtool_help(argv[0]);
 		return -EINVAL;
 	}
-	dev = argv[optind];
+
+	if ((dev = realpath(argv[optind], NULL)) == NULL) {
+		fprintf(stderr, "nandtool: failed to resolve path (%s): %s\n", argv[optind], strerror(errno));
+		return 1;
+	}
+
 
 	if ((err = lookup(dev, NULL, &nandtool_common.oid)) < 0) {
 		fprintf(stderr, "nandtool: failed to lookup device (%s), err: %d\n", dev, err);
+		free(dev);
 		return 1;
 	}
 
 	if ((err = open(dev, O_RDWR)) < 0) {
 		fprintf(stderr, "nandtool: failed to open device (%s), err: %d\n", dev, err);
+		free(dev);
 		return 1;
 	}
 	nandtool_common.fd = err;
@@ -228,6 +235,7 @@ int main(int argc, char **argv)
 		err = -EFAULT;
 		fprintf(stderr, "nandtool: failed to get device info (%s), err: %d\n", dev, err);
 		close(nandtool_common.fd);
+		free(dev);
 		return 1;
 	}
 
@@ -244,5 +252,6 @@ int main(int argc, char **argv)
 
 	close(nandtool_common.fd);
 
+	free(dev);
 	return (err < 0) ? 1 : 0;
 }


### PR DESCRIPTION
## Description
- fix exit code on success 
- fix negative exit codes
- nandwrite: make possible to use non-absolute device paths (needed for device symlinks to work)
- better logging in non-interactive run
- add option to write jffs2 cleanmarkers 
(WARN: not useable on imx6ull right now due to bug in write() when meta
on flash is non-empty)

## Motivation and Context
DTR-181

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imx6ull`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
