### PR TITLE
psh: history: print help message when wrong arguments are passed

### DIFF
--- a/core/psh/pshapp/pshapp.c
+++ b/core/psh/pshapp/pshapp.c
@@ -76,37 +76,37 @@ typedef struct {
 
 /* Binary (base 2) prefixes */
 static const char *bp[] = {
-	"",   /* 2^0         */
-	"K",  /* 2^10   kibi */
-	"M",  /* 2^20   mebi */
-	"G",  /* 2^30   gibi */
-	"T",  /* 2^40   tebi */
-	"P",  /* 2^50   pebi */
-	"E",  /* 2^60   exbi */
-	"Z",  /* 2^70   zebi */
-	"Y"   /* 2^80   yobi */
+	"",  /* 2^0         */
+	"K", /* 2^10   kibi */
+	"M", /* 2^20   mebi */
+	"G", /* 2^30   gibi */
+	"T", /* 2^40   tebi */
+	"P", /* 2^50   pebi */
+	"E", /* 2^60   exbi */
+	"Z", /* 2^70   zebi */
+	"Y"  /* 2^80   yobi */
 };
 
 
 /* SI (base 10) prefixes */
-static const char* si[] = {
-	"y",  /* 10^-24 yocto */
-	"z",  /* 10^-21 zepto */
-	"a",  /* 10^-18 atto  */
-	"f",  /* 10^-15 femto */
-	"p",  /* 10^-12 pico  */
-	"n",  /* 10^-9  nano  */
-	"u",  /* 10^-6  micro */
-	"m",  /* 10^-3  milli */
-	"",   /* 10^0         */
-	"k",  /* 10^3   kilo  */
-	"M",  /* 10^6   mega  */
-	"G",  /* 10^9   giga  */
-	"T",  /* 10^12  tera  */
-	"P",  /* 10^15  peta  */
-	"E",  /* 10^18  exa   */
-	"Z",  /* 10^21  zetta */
-	"Y",  /* 10^24  yotta */
+static const char *si[] = {
+	"y", /* 10^-24 yocto */
+	"z", /* 10^-21 zepto */
+	"a", /* 10^-18 atto  */
+	"f", /* 10^-15 femto */
+	"p", /* 10^-12 pico  */
+	"n", /* 10^-9  nano  */
+	"u", /* 10^-6  micro */
+	"m", /* 10^-3  milli */
+	"",  /* 10^0         */
+	"k", /* 10^3   kilo  */
+	"M", /* 10^6   mega  */
+	"G", /* 10^9   giga  */
+	"T", /* 10^12  tera  */
+	"P", /* 10^15  peta  */
+	"E", /* 10^18  exa   */
+	"Z", /* 10^21  zetta */
+	"Y", /* 10^24  yotta */
 };
 
 
@@ -199,20 +199,20 @@ int psh_prefix(unsigned int base, int x, int y, unsigned int prec, char *buff)
 		return -EINVAL;
 
 	switch (base) {
-	/* Binary prefix */
-	case 2:
-		fp = psh_bp;
-		offs = BP_EXP_OFFS;
-		break;
+		/* Binary prefix */
+		case 2:
+			fp = psh_bp;
+			offs = BP_EXP_OFFS;
+			break;
 
-	/* SI prefix */
-	case 10:
-		fp = psh_si;
-		offs = SI_EXP_OFFS;
-		break;
+		/* SI prefix */
+		case 10:
+			fp = psh_si;
+			offs = SI_EXP_OFFS;
+			break;
 
-	default:
-		return -EINVAL;
+		default:
+			return -EINVAL;
 	}
 
 	/* div < 0 => accumulate extra exponents in x */
@@ -574,7 +574,8 @@ static int psh_readcmd(struct termios *orig, psh_hist_t *cmdhist, char **cmd)
 			/* TAB => autocomplete paths */
 			else if (c == '\t') {
 				path = (hp != cmdhist->he) ? cmdhist->entries[hp].cmd : *cmd;
-				for (i = n; i && (path[i - 1] != ' ') && (path[i - 1] != '\0'); i--);
+				for (i = n; i && (path[i - 1] != ' ') && (path[i - 1] != '\0'); i--)
+					;
 
 				/* Skip empty path */
 				if (i == n)
@@ -913,22 +914,22 @@ int psh_history(int argc, char **argv)
 	psh_hist_t *cmdhist = pshapp_common.cmdhist;
 
 	if (cmdhist == NULL) {
-		fprintf(stderr,"psh: history not initialized\n");
+		fprintf(stderr, "psh: history not initialized\n");
 		return EFAULT;
 	}
 
 	while ((c = getopt(argc, argv, "ch")) != -1) {
 		switch (c) {
-		case 'c':
-			clear = 1;
-			break;
+			case 'c':
+				clear = 1;
+				break;
 
-		case 'h':
-		default:
-			printf("usage: %s [options] or no args to print command history\n", argv[0]);
-			printf("  -c:  clears command history\n");
-			printf("  -h:  shows this help message\n");
-			return EOK;
+			case 'h':
+			default:
+				printf("usage: %s [options] or no args to print command history\n", argv[0]);
+				printf("  -c:  clears command history\n");
+				printf("  -h:  shows this help message\n");
+				return EOK;
 		}
 	}
 


### PR DESCRIPTION
JIRA: CI-99

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
- psh: apply clang-format to pshapp.c
- psh: history: print help message when wrong arguments are passed

before change:
![Screenshot from 2022-01-10 11-29-16](https://user-images.githubusercontent.com/77304431/148751321-94e42a05-59d6-4f06-b6ac-b1c88c0dda1d.png)
after change:
![Screenshot from 2022-01-10 11-27-37](https://user-images.githubusercontent.com/77304431/148751236-a79b305c-5717-4819-8d68-f962503f0090.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/phoenix-rtos/phoenix-rtos-project/issues/250

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
