### PR TITLE
Fixes for `runfile` and `touch`

### DIFF
--- a/psh/runfile/runfile.c
+++ b/psh/runfile/runfile.c
@@ -26,10 +26,14 @@
 int psh_runfile(int argc, char **argv)
 {
 	pid_t pid;
+	int err;
 
 	pid = vfork();
 	if (pid > 0) {
-		waitpid(pid, NULL, 0);
+		waitpid(pid, &err, 0);
+		if (err < 0) {
+			fprintf(stderr, "psh: %s execution halted with error code %d\n", argv[0], err);
+		}
 	}
 	else if (!pid) {
 		/* Put process in its own process group */
@@ -77,6 +81,7 @@ int psh_runfile(int argc, char **argv)
 	/* Take back terminal control */
 	tcsetpgrp(STDIN_FILENO, getpgid(getpid()));
 
+	/* TODO: add publishing the child process return value to env */
 	return pid > 0 ? EOK : -1;
 }
 

--- a/psh/runfile/runfile.c
+++ b/psh/runfile/runfile.c
@@ -26,14 +26,11 @@
 int psh_runfile(int argc, char **argv)
 {
 	pid_t pid;
-	int err;
 
 	pid = vfork();
 	if (pid > 0) {
-		waitpid(pid, &err, 0);
-		if (err < 0) {
-			fprintf(stderr, "psh: %s execution halted with error code %d\n", argv[0], err);
-		}
+		/* TODO: no child exit code handling */
+		waitpid(pid, NULL, 0);
 	}
 	else if (!pid) {
 		/* Put process in its own process group */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Two fixes for psh applets:
 - `runfile`: add error message if error comes from `waitpid()`
 - `touch`: prepared this command for `utimes()` full implementation

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
 - `runfile` changes:
   - https://github.com/phoenix-rtos/phoenix-rtos-project/issues/248
   - `waitpid()` error message should be visible if it comes from _before_ the execution and after context switch


 - `touch` changes:
   - https://github.com/phoenix-rtos/phoenix-rtos-project/issues/252
   - `touch` currently crashes system if called on binary file and truncates files to zero length if file was present before. 
   - Proposed changes make `touch` prepared for working `utimes()` implementation as currently:
     - `utimes()` uses stub syscall just to satisfy busybox ([code permalink](https://github.com/phoenix-rtos/phoenix-rtos-kernel/blob/3b85faa3db0cb156f678c30dc1d430cc9f0a8f00/posix/posix.c#L1962-L1963))
     - `dummyfs` does not support messages of type `setAttr` of `aTime` and `mTime`
   - Proposed changes make `touch`:
     - not crash the system when used on binary file
     - not truncating already present files to zero length  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
