### PR TITLE
psh/hm: Fixed EINTR not being handled on wait()

### DIFF
--- a/core/psh/hm/hm.c
+++ b/core/psh/hm/hm.c
@@ -17,6 +17,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <sys/rb.h>
+#include <errno.h>
 #include <sys/threads.h>
 
 #include "../psh.h"
@@ -169,10 +170,13 @@ int psh_hm(int argc, char *argv[])
 
 	while (progs != 0) {
 		pid = wait(&status);
+		if (pid < 0)
+			continue;
+
 		t.pid = pid;
 		p = lib_treeof(proc_t, node, lib_rbFind(&hm_common.ptree, &t.node));
 		if (p == NULL) {
-			fprintf(stderr, "hm: Child died, but it's not mine. Ignoring.\n");
+			fprintf(stderr, "hm: Child died, but it's not mine (pid %d). Ignoring.\n", pid);
 			continue;
 		}
 		pid = psh_hm_spawn(p);


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Wrong error msg is produced if hm encounters EINTR during wait()

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (stm32).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
