### PR TITLE
psh: mem: add statement about unavailable page view on non-mmu targets

### DIFF
--- a/psh/mem/mem.c
+++ b/psh/mem/mem.c
@@ -171,9 +171,9 @@ static int psh_mem_process(char *memarg)
 
 static int psh_mem_page(void)
 {
-	int mapsz = 0;
+	int i, mapsz = 0;
 	pageinfo_t *p = NULL;
-	unsigned int i, n;
+	unsigned int n;
 	meminfo_t info;
 	void *rmap;
 
@@ -215,7 +215,12 @@ static int psh_mem_page(void)
 		while (n-- > 0)
 			printf("%c", p->marker);
 	}
-	printf("\n");
+	if (info.page.mapsz < 0) {
+		fprintf(stderr, "mem: Page view unavailable\n");
+	}
+	else {
+		printf("\n");
+	}
 
 	free(info.page.map);
 	return EOK;


### PR DESCRIPTION
JIRA: PD-217

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Add handling `page.mapsz` with negative value (means page map hasn't been initialized and -p option for `mem` command isn't available)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to:
 - https://github.com/phoenix-rtos/phoenix-rtos-project/issues/281

When 
 - https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/281 

is merged, calling `mem -p` on non-mmu targets will print blank line. With this change there will be the proper statement.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: (https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/72).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
  - https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/281
- [ ] I will merge this PR by myself when appropriate.
