### PR TITLE
psh: ls: fix calling -d without specified directory

### DIFF
--- a/core/psh/ls/ls.c
+++ b/core/psh/ls/ls.c
@@ -419,6 +419,7 @@ int psh_ls(int argc, char **argv)
 	unsigned int i, npaths = 0;
 	int c, nfiles = 0, ret = EOK;
 	char **paths = NULL;
+	char *currdir = NULL;
 	struct dirent *dir;
 	const char *path;
 	DIR *stream;
@@ -485,6 +486,12 @@ int psh_ls(int argc, char **argv)
 	if (optind < argc) {
 		paths = &argv[optind];
 		npaths = argc - optind;
+	}
+
+	if (psh_ls_common.dir && (npaths == 0)) {
+		currdir = ".";
+		paths = &currdir;
+		npaths++;
 	}
 
 	if ((npaths > 0) && ((psh_ls_common.odir = calloc(npaths, sizeof(int *))) == NULL)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
- handle calling ls with -d option without additional arguments
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/phoenix-rtos/phoenix-rtos-project/issues/190

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: (https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/52).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
