### PR TITLE
touch: utimes buffer fix

### DIFF
--- a/psh/touch/touch.c
+++ b/psh/touch/touch.c
@@ -31,7 +31,6 @@ int psh_touch(int argc, char **argv)
 {
 	FILE *file;
 	int i;
-	struct timeval times;
 
 	if (argc < 2) {
 		fprintf(stderr, "usage: %s <file path>...\n", argv[0]);
@@ -53,9 +52,7 @@ int psh_touch(int argc, char **argv)
 		else {
 			/* file exists -> update timestamps */
 			fclose(file);
-			times.tv_sec = time(NULL);
-			times.tv_usec = 0;
-			if (utimes(argv[i], &times) == 0)
+			if (utimes(argv[i], NULL) == 0)
 				continue;
 		}
 		fprintf(stderr, "psh: failed to touch %s\n", argv[i]);
@@ -67,6 +64,6 @@ int psh_touch(int argc, char **argv)
 
 void __attribute__((constructor)) touch_registerapp(void)
 {
-	static psh_appentry_t app = {.name = "touch", .run = psh_touch, .info = psh_touchinfo};
+	static psh_appentry_t app = { .name = "touch", .run = psh_touch, .info = psh_touchinfo };
 	psh_registerapp(&app);
 }


### PR DESCRIPTION
JIRA: PD-214

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
fix for https://github.com/phoenix-rtos/phoenix-rtos-utils/pull/112

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Uncatched error (due to not testing touch due to not working touch etc.) of buffer overflow in `utimes()` usage

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
