### PR TITLE
psh/cat: Fixed cat's return value

### DIFF
--- a/psh/cat/cat.c
+++ b/psh/cat/cat.c
@@ -35,8 +35,7 @@ static void psh_cat_help(const char *prog)
 
 static inline int psh_cat_isExit(void)
 {
-	return ((psh_common.sigint != 0) || (psh_common.sigquit != 0) ||
-		(psh_common.sigstop != 0)) ? 1 : 0;
+	return ((psh_common.sigint != 0) || (psh_common.sigquit != 0) || (psh_common.sigstop != 0)) ? 1 : 0;
 }
 
 
@@ -103,6 +102,6 @@ int psh_cat(int argc, char **argv)
 
 void __attribute__((constructor)) cat_registerapp(void)
 {
-	static psh_appentry_t app = {.name = "cat", .run = psh_cat, .info = psh_catinfo};
+	static psh_appentry_t app = { .name = "cat", .run = psh_cat, .info = psh_catinfo };
 	psh_registerapp(&app);
 }

--- a/psh/cat/cat.c
+++ b/psh/cat/cat.c
@@ -3,8 +3,8 @@
  *
  * cat - concatenate file(s) to standard output
  *
- * Copyright 2017, 2018, 2020, 2021 Phoenix Systems
- * Author: Pawel Pisarczyk, Jan Sikorski, Lukasz Kosinski, Mateusz Niewiadomski
+ * Copyright 2017, 2018, 2020-2022 Phoenix Systems
+ * Author: Pawel Pisarczyk, Jan Sikorski, Lukasz Kosinski, Mateusz Niewiadomski, Aleksander Kaminski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -19,6 +19,8 @@
 
 #include "../psh.h"
 
+#define SIZE_BUFF 1024
+
 void psh_catinfo(void)
 {
 	printf("concatenate file(s) to standard output");
@@ -31,40 +33,71 @@ static void psh_cat_help(const char *prog)
 }
 
 
+static inline int psh_cat_isExit(void)
+{
+	return ((psh_common.sigint != 0) || (psh_common.sigquit != 0) ||
+		(psh_common.sigstop != 0)) ? 1 : 0;
+}
+
+
 int psh_cat(int argc, char **argv)
 {
 	FILE *file;
 	char *buff;
-	size_t ret;
-	int c;
+	size_t ret, len, wrote;
+	int c, i, retval = EXIT_SUCCESS;
 
 	while ((c = getopt(argc, argv, "h")) != -1) {
 		switch (c) {
-		case 'h':
-		default:
-			psh_cat_help(argv[0]);
-			return EOK;
+			case 'h':
+				psh_cat_help(argv[0]);
+				break;
+			default:
+				psh_cat_help(argv[0]);
+				retval = EXIT_FAILURE;
+				break;
 		}
+
+		return retval;
 	}
 
-	if ((buff = malloc(1024)) == NULL) {
+	/* FIXME? We're operating on streams, there should be no need for big buffers */
+	if ((buff = malloc(SIZE_BUFF)) == NULL) {
 		fprintf(stderr, "cat: out of memory\n");
-		return -ENOMEM;
+		return EXIT_FAILURE;
 	}
 
-	for (; !psh_common.sigint && !psh_common.sigquit && !psh_common.sigstop && (optind < argc); optind++) {
-		if ((file = fopen(argv[optind], "r")) == NULL) {
-			fprintf(stderr, "cat: %s no such file\n", argv[optind]);
+	for (i = optind; (psh_cat_isExit() == 0) && (i < argc); ++i) {
+		if ((file = fopen(argv[i], "r")) == NULL) {
+			fprintf(stderr, "cat: %s no such file\n", argv[i]);
+			retval = EXIT_FAILURE;
 		}
 		else {
-			while (!psh_common.sigint && !psh_common.sigquit && !psh_common.sigstop && ((ret = fread(buff, 1, 1024, file)) > 0))
-				fwrite(buff, 1, ret, stdout);
+			while (psh_cat_isExit() == 0) {
+				if ((len = fread(buff, 1, SIZE_BUFF, file)) > 0) {
+					wrote = 0;
+					do {
+						if ((ret = fwrite(buff + wrote, 1, len, stdout)) == 0) {
+							retval = EXIT_FAILURE;
+							break;
+						}
+						len -= ret;
+						wrote += ret;
+					} while (len > 0);
+				}
+				else {
+					if (ferror(file) != 0) {
+						retval = EXIT_FAILURE;
+					}
+					break;
+				}
+			}
 			fclose(file);
 		}
 	}
 	free(buff);
 
-	return EOK;
+	return retval;
 }
 
 


### PR DESCRIPTION
JIRA: RTOS-160

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Cat returned negative values, also did not return error on file opening.

Also made cat more MISRA friendly. Not really sure about getopt loop, I'm open for sugestions

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix for https://github.com/phoenix-rtos/phoenix-rtos-project/issues/336

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
