### PR TITLE
psh: add `date` applet

### DIFF
--- a/psh/Makefile
+++ b/psh/Makefile
@@ -19,7 +19,7 @@ LOCAL_CFLAGS += -DPSH_SYSEXECWL='"$(PSH_SYSEXECWL)"'
 LOCAL_LDFLAGS := -z stack-size=4096 -z noexecstack
 
 # TODO: search for dirs?
-PSH_ALLCOMMANDS := bind cat df dmesg echo edit exec hm kill ls mem mkdir mount \
+PSH_ALLCOMMANDS := bind cat date df dmesg echo edit exec hm kill ls mem mkdir mount \
 nc nslookup perf ping pm ps reboot runfile sync sysexec top touch uptime
 PSH_COMMANDS ?= $(PSH_ALLCOMMANDS)
 PSH_APPLETS := pshapp help $(filter $(PSH_ALLCOMMANDS), $(PSH_COMMANDS))

--- a/psh/date/date.c
+++ b/psh/date/date.c
@@ -1,0 +1,226 @@
+/*
+ * Phoenix-RTOS
+ *
+ * date - print or set the system date and time
+ *
+ * Copyright 2022 Phoenix Systems
+ * Author: Mateusz Niewiadomski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include "../psh.h"
+
+
+enum mode { mode_skip,
+	mode_help,
+	mode_print,
+	mode_set,
+	mode_parse };
+
+
+static void psh_date_info(void)
+{
+	printf("print/set the system date and time");
+}
+
+
+static void psh_date_help(const char *prog)
+{
+	printf(
+		"Usage: %s [-h] [-s EPOCH] [-d @EPOCH] [+FORMAT]\n"
+		"  -h:  shows this help message\n"
+		"  -s:  set system time described by EPOCH (POSIX time format)\n"
+		"  -d:  display time described by EPOCH (POSIX time format)\n"
+		"  FORMAT: string with POSIX date formatting characters\n"
+		"NOTE: FORMAT string not supported by options: '-s', '-d'\n",
+		prog);
+}
+
+
+static int psh_date_print(const struct timeval *tv, const char *format)
+{
+	struct tm *tinfo;
+	const char *defformat = "+%a, %d %b %y %H:%M:%S";
+	char buf[64];
+
+	if (format == NULL) {
+		format = defformat;
+	}
+	else if (format[0] != '+') {
+		fprintf(stderr, "date: invalid format '%s'\n", format);
+		return 1;
+	}
+
+	tinfo = localtime(&(tv->tv_sec));
+	if (tinfo == NULL) {
+		fprintf(stderr, "date: time get error!\n");
+		return 1;
+	}
+
+	/* passing `&format[1]` for omission of '+' at the beginning */
+	if (strftime(buf, sizeof(buf), &format[1], tinfo) == 0) {
+		fprintf(stderr, "date: '%s' expansion too long\n", format);
+		return 1;
+	}
+	printf("%s\n", buf);
+
+	return 0;
+}
+
+
+static int psh_date_get(const char *format)
+{
+	struct timeval tv;
+
+	time(&(tv.tv_sec));
+	tv.tv_usec = 0;
+	return psh_date_print(&tv, format);
+}
+
+
+static int psh_date_convert(const char *timestring, const char *format, struct timeval *tv)
+{
+	char *end;
+
+	if (timestring == NULL) {
+		return 1;
+	}
+
+	/* FIXME: strptime() should be used below: unimplemented in libphoenix */
+	if (format != NULL) {
+		fprintf(stderr, "date: chosen option does not support FORMAT\n");
+		return 1;
+	}
+	if (timestring[0] == '@') {
+		tv->tv_usec = 0;
+		tv->tv_sec = strtoull(&timestring[1], &end, 10);
+		if ((end != timestring) && (*end == '\0')) {
+			return 0;
+		}
+	}
+
+	fprintf(stderr, "date: invalid date '%s'\n", timestring);
+	return 1;
+}
+
+
+static int psh_date_parse(const char *timestring, const char *format)
+{
+	struct timeval tv;
+
+	if (timestring != NULL && timestring[0] != '@') {
+		fprintf(stderr, "date: invalid date '%s'\n", timestring);
+		return 1;
+	}
+
+	/* error message printed by psh_date_convert() */
+	if (psh_date_convert(timestring, format, &tv) != 0) {
+		return 1;
+	}
+
+	return psh_date_print(&tv, NULL);
+}
+
+
+static int psh_date_set(const char *timestring, const char *format)
+{
+	struct timeval tv;
+	struct timezone tz = { .tz_dsttime = 0, .tz_minuteswest = 0 };
+
+	/* error message printed by psh_date_convert() */
+	if (psh_date_convert(timestring, format, &tv) != 0) {
+		return 1;
+	}
+
+	if (settimeofday(&tv, &tz) != 0) {
+		fprintf(stderr, "date: time set failed: %s\n", strerror(errno));
+		return 1;
+	}
+
+	return psh_date_get(NULL);
+}
+
+
+static int psh_date(int argc, char **argv)
+{
+	int c, status = 1;
+	const char *timestring = NULL, *format = NULL;
+	enum mode m = mode_print;
+
+	while ((c = getopt(argc, argv, "hs:d:")) != -1) {
+		switch (c) {
+			case 'h':
+				m = mode_help;
+				break;
+
+			case 's':
+				m = mode_set;
+				timestring = optarg;
+				break;
+
+			case 'd':
+				m = mode_parse;
+				timestring = optarg;
+				break;
+
+			default:
+				m = mode_skip;
+				break;
+		}
+	}
+
+	/* evaluate additional arguments/format */
+	if (m != mode_skip) {
+		if (argc > optind + 1) {
+			m = mode_skip;
+			fprintf(stderr, "Unrecognized argument: %s\n", argv[optind + 1]);
+		}
+		else if (argc != optind) {
+			format = argv[optind];
+		}
+	}
+
+	/* run proper option */
+	switch (m) {
+		case mode_set:
+			status = psh_date_set(timestring, format);
+			break;
+
+		case mode_print:
+			status = psh_date_get(format);
+			break;
+
+		case mode_parse:
+			status = psh_date_parse(timestring, format);
+			break;
+
+		case mode_help:
+			psh_date_help(argv[0]);
+			status = 0;
+			break;
+
+		default:
+			/* everything set for default */
+			break;
+	}
+
+	return (status == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+
+void __attribute__((constructor)) date_registerapp(void)
+{
+	static psh_appentry_t app = { .name = "date", .run = psh_date, .info = psh_date_info };
+	psh_registerapp(&app);
+}


### PR DESCRIPTION
DONE: PD-249

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Add simple date command

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

 - I wanted to put 'Test Driven Developement' to work, so I trained on developement of simple psh applet `date`. 
 - This applet was developed alongside with tests which are in separate PR:
   - https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/98
 - Documentation PR:
   - https://github.com/phoenix-rtos/phoenix-rtos-doc/pull/110 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation (https://github.com/phoenix-rtos/phoenix-rtos-doc/pull/110)
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
