### PR TITLE
psh: ls: fix printing files longer than window size

### DIFF
--- a/psh/ls/ls.c
+++ b/psh/ls/ls.c
@@ -106,7 +106,7 @@ static size_t *psh_ls_computerows(size_t *rows, size_t *cols, size_t nfiles)
 
 	/* Estimate lower bound of nrows */
 	for (i = 0; i < nfiles; i++)
-		sum += files[i].namelen;
+		sum += min(files[i].namelen, psh_ls_common.ws.ws_col - 1);
 
 	nrows = sum / psh_ls_common.ws.ws_col + 1;
 	ncols = nfiles / nrows + 1;
@@ -124,7 +124,7 @@ static size_t *psh_ls_computerows(size_t *rows, size_t *cols, size_t nfiles)
 		/* Compute widths of each column */
 		for (i = 0; i < nfiles; i++) {
 			col = i / nrows;
-			colsz[col] = max(colsz[col], files[i].namelen + 2);
+			colsz[col] = max(colsz[col], min(files[i].namelen + 2, psh_ls_common.ws.ws_col - 1));
 		}
 		colsz[ncols - 1] -= 2;
 

--- a/psh/ls/ls.c
+++ b/psh/ls/ls.c
@@ -145,17 +145,27 @@ static size_t *psh_ls_computerows(size_t *rows, size_t *cols, size_t nfiles)
 
 static void psh_ls_printfile(fileinfo_t *file, int width)
 {
-	if (S_ISREG(file->stat.st_mode) && file->stat.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH))
+	unsigned char iscolor = 1;
+	if (S_ISREG(file->stat.st_mode) && file->stat.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH)) {
 		printf(EXE_COLOR);
-	else if (S_ISDIR(file->stat.st_mode))
+	}
+	else if (S_ISDIR(file->stat.st_mode)) {
 		printf(DIR_COLOR);
-	else if (S_ISCHR(file->stat.st_mode) || S_ISBLK(file->stat.st_mode))
+	}
+	else if (S_ISCHR(file->stat.st_mode) || S_ISBLK(file->stat.st_mode)) {
 		printf(DEV_COLOR);
-	else if (S_ISLNK(file->stat.st_mode))
+	}
+	else if (S_ISLNK(file->stat.st_mode)) {
 		printf(SYM_COLOR);
+	}
+	else {
+		iscolor = 0;
+	}
 
 	printf("%-*s", width, file->name);
-	printf("\033[0m");
+	if (iscolor) {
+		printf("\033[0m");
+	}
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

- handle printing files with names longer than window size
- disable reset attributes esc sequence, where it's not necessarily

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

JIRA: RTOS-165

 - https://github.com/phoenix-rtos/phoenix-rtos-project/issues/347

- before change:
![Screenshot from 2022-03-10 18-56-55](https://user-images.githubusercontent.com/77304431/157725941-85faf71e-261a-4647-b6c0-4fc9ecbe2ea4.png)

- after change:
![Screenshot from 2022-03-10 18-57-36](https://user-images.githubusercontent.com/77304431/157725956-6697c7be-0d24-4172-a96f-9d6ab6c87a56.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
