### PR TITLE
nandtool: add option to set non-interactive mode explicitly

### DIFF
--- a/nandtool/nandtool.c
+++ b/nandtool/nandtool.c
@@ -189,6 +189,7 @@ static void nandtool_help(const char *prog)
 	printf("\t-r                - flash raw data\n");
 	printf("\t-s <block>        - start flashing from given block (requires -i)\n");
 	printf("\t-h                - print this help message\n");
+	printf("\t-q                - quiet: don't print flashing progress\n");
 }
 
 
@@ -201,7 +202,7 @@ int main(int argc, char **argv)
 	if (isatty(STDOUT_FILENO))
 		nandtool_common.interactive = 1;
 
-	while ((c = getopt(argc, argv, "e:i:r:s:chj")) != -1) {
+	while ((c = getopt(argc, argv, "e:i:r:s:chjq")) != -1) {
 		switch (c) {
 			case 'e':
 				tok = strtok(optarg, ":");
@@ -230,17 +231,21 @@ int main(int argc, char **argv)
 				check = 1;
 				break;
 
+			case 'q':
+				nandtool_common.interactive = 0;
+				break;
+
 			case 'h':
 			default:
 				nandtool_help(argv[0]);
-				return EOK;
+				return 0;
 		}
 	}
 
 	if (optind >= argc) {
 		fprintf(stderr, "nandtool: missing device arg\n");
 		nandtool_help(argv[0]);
-		return -EINVAL;
+		return 1;
 	}
 
 	if ((dev = realpath(argv[optind], NULL)) == NULL) {


### PR DESCRIPTION
JIRA: DTR-124

`nandtool` floods UART in stage2 FW upgrade resulting sometimes in WATCHDOG restart.

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imx6ull`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
