### PR TITLE
pshapp: Allow execute both absolute and relative paths

### DIFF
--- a/psh/pshapp/pshapp.c
+++ b/psh/pshapp/pshapp.c
@@ -1001,8 +1001,8 @@ static int psh_run(int exitable, const char *console)
 	psh_histent_t *entry;
 	const psh_appentry_t *app;
 	struct termios orig;
-	char *cmd, **argv;
-	int err, n, argc;
+	char *tmp, *cmd, **argv;
+	int cnt, err, n, argc;
 	pid_t pgrp;
 	int retries;
 
@@ -1112,8 +1112,25 @@ static int psh_run(int exitable, const char *console)
 		optind = 1;
 
 		/* Find and run */
-		if ((app = psh_findapp(argv[0])) == NULL && argv[0][0] == '/')
-			app = psh_findapp("/");
+		app = psh_findapp(argv[0]);
+		if (app == NULL) {
+
+			/* Allow executable path start with "/", "./", "../" */
+			cnt = 0;
+			for (tmp = argv[0]; *tmp; tmp++) {
+				if (*tmp != '.') {
+					if (*tmp != '/') {
+						cnt = 3;
+					}
+					break;
+				}
+				cnt++;
+			}
+
+			if (cnt < 3 && *tmp == '/') {
+				app = psh_findapp("/");
+			}
+		}
 
 		if (app != NULL) {
 			err = app->run(argc, argv);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
JIRA: RTOS-232

## Description
<!--- Describe your changes shortly -->
Previously, it was only possible to run programs with an absolute path starting with `/`, this change introduces
the ability to run also using a relative path, e.g. relative to working directory.

It is expected that executable path begins with: `/`, `./` or `../` (pre-checked in `pshapp.c` - this change)

Allowed paths are (depending on current working direcory, eg. after changing it with `cd /usr/bin`):
```bash
/usr/bin/hello
./hello
../bin/hello
../../../../../usr/bin/hello
./././hello
```
Full path is then checked by `runfile.c:` `execv()`->`resolve_path()`


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
