### PR TITLE
psh: fix return codes for history, mkdir, touch and mem

### DIFF
--- a/psh/mem/mem.c
+++ b/psh/mem/mem.c
@@ -38,7 +38,7 @@ static int psh_mem_summary(void)
 	printf("(%d+%d)/%dKB ", (info.page.alloc - info.page.boot) / 1024, info.page.boot / 1024, (info.page.alloc + info.page.free) / 1024);
 	printf("%d/%d entries\n", info.entry.total - info.entry.free, info.entry.total);
 
-	return EOK;
+	return 0;
 }
 
 
@@ -166,7 +166,7 @@ static int psh_mem_process(char *memarg)
 	free(info.entry.map);
 	free(info.entry.kmap);
 
-	return EOK;
+	return 0;
 }
 
 
@@ -224,7 +224,7 @@ static int psh_mem_page(void)
 	}
 
 	free(info.page.map);
-	return EOK;
+	return 0;
 }
 
 
@@ -322,33 +322,33 @@ static int psh_mem(int argc, char **argv)
 	int c;
 
 	if (argc == 1)
-		return psh_mem_summary();
+		return psh_mem_summary() < 0 ? EXIT_FAILURE : EXIT_SUCCESS;
 
 	while ((c = getopt(argc, argv, "mpsh")) != -1) {
 		switch (c) {
 		case 'm':
-			return psh_mem_process(argv[optind]);
+			return psh_mem_process(argv[optind]) < 0 ? EXIT_FAILURE : EXIT_SUCCESS;
 
 		case 'p':
-			return psh_mem_page();
+			return psh_mem_page() < 0 ? EXIT_FAILURE : EXIT_SUCCESS;
 
 		case 'h':
-			return psh_help(argv[0]);
+			return psh_help(argv[0]) < 0 ? EXIT_FAILURE : EXIT_SUCCESS;
 
 		case 's':
-			return psh_sharedMaps();
+			return psh_sharedMaps() < 0 ? EXIT_FAILURE : EXIT_SUCCESS;
 
 		default:
-			return EOK;
+			return EXIT_FAILURE;
 		}
 	}
 
 	if (optind < argc) {
 		fprintf(stderr, "mem: unknown argument: %s\n", argv[optind]);
-		return -EINVAL;
+		return EXIT_FAILURE;
 	}
 
-	return EOK;
+	return EXIT_SUCCESS;
 }
 
 

--- a/psh/mkdir/mkdir.c
+++ b/psh/mkdir/mkdir.c
@@ -13,6 +13,7 @@
 
 #include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <sys/stat.h>
@@ -28,20 +29,23 @@ void psh_mkdirinfo(void)
 
 int psh_mkdir(int argc, char **argv)
 {
-	int i;
+	int i, err;
+
+	err = EXIT_SUCCESS;
 
 	if (argc < 2) {
 		fprintf(stderr, "usage: %s <dir path>...\n", argv[0]);
-		return -EINVAL;
+		return EXIT_FAILURE;
 	}
 
 	for (i = 1; i < argc; i++) {
 		if (mkdir(argv[i], 0) < 0) {
+			err = EXIT_FAILURE;
 			fprintf(stderr, "mkdir: failed to create %s directory: %s\n", argv[i], strerror(errno));
 		}
 	}
 
-	return EOK;
+	return err;
 }
 
 

--- a/psh/pshapp/pshapp.c
+++ b/psh/pshapp/pshapp.c
@@ -254,7 +254,7 @@ int psh_prefix(unsigned int base, int x, int y, unsigned int prec, char *buff)
 	else
 		sprintf(buff, "%d%s", ipart, prefix);
 
-	return EOK;
+	return 0;
 }
 
 
@@ -279,7 +279,7 @@ static void psh_printhistent(psh_histent_t *entry)
 static int psh_completepath(char *dir, char *base, char ***files)
 {
 	size_t i, size = 32, dlen = strlen(dir), blen = strlen(base);
-	int nfiles = 0, err = EOK;
+	int nfiles = 0, err = 0;
 	char *path, **rfiles;
 	struct stat st;
 	DIR *stream;
@@ -412,7 +412,7 @@ static int psh_printfiles(char **files, int nfiles)
 	fflush(stdout);
 	free(colsz);
 
-	return EOK;
+	return 0;
 }
 
 
@@ -501,7 +501,7 @@ extern void cfmakeraw(struct termios *termios);
 
 static int psh_readcmd(struct termios *orig, psh_hist_t *cmdhist, char **cmd)
 {
-	int i, k, nfiles, err = EOK, esc = 0, n = 0, m = 0, ln = 0, hp = cmdhist->he;
+	int i, k, nfiles, err = 0, esc = 0, n = 0, m = 0, ln = 0, hp = cmdhist->he;
 	char c, *path, *fpath, *dir, *base, **files, buff[8];
 	struct termios raw = *orig;
 
@@ -820,7 +820,7 @@ static int psh_parsecmd(char *line, int *argc, char ***argv)
 	}
 	(*argv)[*argc] = NULL;
 
-	return EOK;
+	return 0;
 }
 
 
@@ -897,7 +897,7 @@ static int psh_runscript(char *path)
 	free(line);
 	fclose(stream);
 
-	return EOK;
+	return 0;
 }
 
 
@@ -923,7 +923,7 @@ int psh_history(int argc, char **argv)
 
 	if (cmdhist == NULL) {
 		fprintf(stderr, "psh: history not initialized\n");
-		return EFAULT;
+		return EXIT_FAILURE;
 	}
 
 	/* Process options */
@@ -940,14 +940,14 @@ int psh_history(int argc, char **argv)
 
 				default:
 					psh_historyhelp();
-					return EOK;
+					return EXIT_FAILURE;
 			}
 		}
 
 		/* History command doesn't take any arguments */
 		if (optind < argc) {
 			psh_historyhelp();
-			return EOK;
+			return EXIT_FAILURE;
 		}
 
 		if (clear) {
@@ -973,7 +973,7 @@ int psh_history(int argc, char **argv)
 		}
 	}
 
-	return EOK;
+	return EXIT_SUCCESS;
 }
 
 
@@ -1191,7 +1191,7 @@ int psh_pshapp(int argc, char **argv)
 					printf("  -i <script path>:   selects psh script to execute\n");
 					printf("  -t <terminal dev>:  path to terminal device, default %s\n", _PATH_CONSOLE);
 					printf("  -h:                 shows this help message\n");
-					return EOK;
+					return EXIT_SUCCESS;
 			}
 		}
 
@@ -1199,14 +1199,14 @@ int psh_pshapp(int argc, char **argv)
 			path = argv[optind];
 
 		if (path != NULL)
-			return psh_runscript(path);
+			return psh_runscript(path) < 0 ? EXIT_FAILURE : EXIT_SUCCESS;
 	}
 	/* Run shell interactively */
 	else {
-		return psh_run(1, consolePath);
+		return psh_run(1, consolePath) < 0 ? EXIT_FAILURE : EXIT_SUCCESS;
 	}
 
-	return -ENOSYS;
+	return EXIT_FAILURE;
 }
 
 

--- a/psh/touch/touch.c
+++ b/psh/touch/touch.c
@@ -13,6 +13,7 @@
 
 #include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <time.h>
@@ -30,11 +31,13 @@ void psh_touchinfo(void)
 int psh_touch(int argc, char **argv)
 {
 	FILE *file;
-	int i;
+	int i, err;
+
+	err = EXIT_SUCCESS;
 
 	if (argc < 2) {
 		fprintf(stderr, "usage: %s <file path>...\n", argv[0]);
-		return -EINVAL;
+		return EXIT_FAILURE;
 	}
 
 	for (i = 1; i < argc; i++) {
@@ -55,10 +58,11 @@ int psh_touch(int argc, char **argv)
 			if (utimes(argv[i], NULL) == 0)
 				continue;
 		}
+		err = EXIT_FAILURE;
 		fprintf(stderr, "psh: failed to touch %s\n", argv[i]);
 	}
 
-	return EOK;
+	return err;
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

 - psh: fix mem return codes
 - psh: fix touch return codes
 - psh: fix mkdir return codes
 - psh: fix applets return codes in pshapp.c

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

 - EOK is not cross-platform
 - Sometimes 0 was returned even if error had been occurred
 - Errno shall not be returned as exit status


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
