### PR TITLE
psh: fix passing double dash to history, mem and echo

### DIFF
--- a/psh/echo/echo.c
+++ b/psh/echo/echo.c
@@ -90,8 +90,8 @@ static int psh_echo(int argc, char **argv)
 		}
 	}
 
-	for (i = optind; i < argend; ++i) {
-		if (i != optind) {
+	for (i = 1; i < argend; ++i) {
+		if (i != 1) {
 			fputc(' ', output);
 		}
 

--- a/psh/mem/mem.c
+++ b/psh/mem/mem.c
@@ -319,7 +319,7 @@ static int psh_sharedMaps(void)
 
 static int psh_mem(int argc, char **argv)
 {
-	int c;
+	int c, ind;
 
 	if (argc == 1)
 		return psh_mem_summary() < 0 ? EXIT_FAILURE : EXIT_SUCCESS;
@@ -343,8 +343,9 @@ static int psh_mem(int argc, char **argv)
 		}
 	}
 
-	if (optind < argc) {
-		fprintf(stderr, "mem: unknown argument: %s\n", argv[optind]);
+	if (optind <= argc) {
+		ind = (optind == argc) ? optind - 1 : optind;
+		fprintf(stderr, "mem: unknown argument: %s\n", argv[ind]);
 		return EXIT_FAILURE;
 	}
 

--- a/psh/pshapp/pshapp.c
+++ b/psh/pshapp/pshapp.c
@@ -945,7 +945,7 @@ int psh_history(int argc, char **argv)
 		}
 
 		/* History command doesn't take any arguments */
-		if (optind < argc) {
+		if (optind <= argc && !help && !clear) {
 			psh_historyhelp();
 			return EXIT_FAILURE;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
