### PR TITLE
psh: reset getopt by setting optind to 0 not 1

### DIFF
--- a/psh/pshapp/pshapp.c
+++ b/psh/pshapp/pshapp.c
@@ -1109,7 +1109,7 @@ static int psh_run(int exitable, const char *console)
 		psh_common.sigstop = 0;
 
 		/* Reset getopt */
-		optind = 1;
+		optind = 0;
 
 		/* Find and run */
 		app = psh_findapp(argv[0]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

 - psh: reset getopt by setting optind to 0 not 1
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

 - It's necessary to properly reset getopt function (requires the change mentioned below). 9ed7c715d3e97f3112e3cbb30920171cf64163fa libphoenix

 - JIRA: RTOS-271

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
