### PR TITLE
nandtool: Add dumping functionality

### DIFF
--- a/nandtool/flashmng.c
+++ b/nandtool/flashmng.c
@@ -42,6 +42,30 @@ static struct cleanmarker {
 };
 
 
+int flashmng_readraw(oid_t oid, offs_t addr, void *data, size_t size)
+{
+	msg_t msg = { 0 };
+	flash_i_devctl_t *idevctl = (flash_i_devctl_t *)msg.i.raw;
+	flash_o_devctl_t *odevctl = (flash_o_devctl_t *)msg.o.raw;
+
+	msg.type = mtDevCtl;
+	msg.o.data = data;
+	msg.o.size = size;
+
+	idevctl->type = flashsrv_devctl_readraw;
+	idevctl->readraw.oid = oid;
+	idevctl->readraw.size = size;
+	/* FIXME: Now imx6ull nand DevCtl API supports only 32-bit offsets */
+	idevctl->readraw.address = (uint32_t)addr;
+
+	if (msgSend(oid.port, &msg) < 0) {
+		return -1;
+	}
+
+	return odevctl->err;
+}
+
+
 static int write_ex(oid_t oid, uint32_t addr, const void *data, size_t size, int type)
 {
 	msg_t msg = { 0 };

--- a/nandtool/flashmng.h
+++ b/nandtool/flashmng.h
@@ -18,6 +18,9 @@
 #include <imx6ull-flashsrv.h>
 
 
+int flashmng_readraw(oid_t oid, offs_t addr, void *data, size_t size);
+
+
 int flashmng_writeraw(oid_t oid, unsigned int page, const void *data, size_t size);
 
 

--- a/nandtool/nandtool.c
+++ b/nandtool/nandtool.c
@@ -169,7 +169,7 @@ static int nandtool_check(void)
 	int err;
 
 	if ((err = flashmng_checkbad(nandtool_common.oid)) < 0) {
-		fprintf(stderr, "nandtool: failed to complete bad block check, err: %d\n", err);
+		fprintf(stderr, "nandtool: failed to complete bad block check, %d\n", err);
 		return err;
 	}
 
@@ -177,13 +177,116 @@ static int nandtool_check(void)
 }
 
 
+static int nandtool_dump(const char *outpath, unsigned int start, unsigned int nblocks, int oob)
+{
+	const flashsrv_info_t *info;
+	ssize_t len;
+	offs_t blocksz, partsz, pagesz;
+	offs_t addr, endaddr, bytes;
+	uint8_t *buf;
+	int ret = 0;
+	int outfd;
+
+	outfd = open(outpath, O_WRONLY | O_CREAT);
+	if (outfd < 0) {
+		perror("nandtool_dump: Fail to open output file");
+		return -EINVAL;
+	}
+
+	info = flashmng_info(nandtool_common.oid);
+	if (info == NULL) {
+		fprintf(stderr, "nandtool_dump: Fail to retrieve partition info\n");
+		close(outfd);
+		return -EFAULT;
+	}
+
+	if (!oob) {
+		pagesz = info->writesz;
+		blocksz = info->erasesz;
+		partsz = info->size;
+	}
+	else {
+		pagesz = info->metasz + info->writesz;
+		blocksz = (info->erasesz / info->writesz) * pagesz;
+		partsz = (info->size / info->erasesz) * blocksz;
+	}
+
+	addr = start * blocksz;
+
+	if (!oob) {
+		if (lseek(nandtool_common.fd, addr, SEEK_SET) < 0) {
+			perror("nandtool_dump: lseek failed");
+			close(outfd);
+			return -EINVAL;
+		}
+	}
+
+	buf = malloc(pagesz);
+	if (buf == NULL) {
+		perror("nandtool_dump: Fail to allocate memory");
+		close(outfd);
+		return -ENOMEM;
+	}
+
+	if (nblocks == 0) {
+		/* Read everything from start to end of partition */
+		endaddr = partsz;
+	}
+	else {
+		endaddr = addr + nblocks * blocksz;
+	}
+
+	printf("nandtool_dump: %spartition size: %llu, erase block size: %d, write size: %d\n",
+		(oob == 1) ? "raw " : "", partsz, info->erasesz, info->writesz);
+
+	printf("nandtool_dump: Reading from address: 0x%llx to 0x%llx\n", addr, endaddr);
+
+	bytes = 0;
+	while (addr + bytes < endaddr) {
+		if (oob) {
+			len = flashmng_readraw(nandtool_common.oid, addr + bytes, buf, pagesz);
+		}
+		else {
+			len = read(nandtool_common.fd, buf, pagesz);
+		}
+
+		if (len != pagesz) {
+			fprintf(stderr, "nandtool_dump: Fail to read a block at offset: %llx, %s\n", addr + bytes, strerror(errno));
+			ret = -EIO;
+			break;
+		}
+
+		len = write(outfd, buf, pagesz);
+		if (len != pagesz) {
+			fprintf(stderr, "nandtool_dump: Fail to write to output file at offset: %llx, %s\n", bytes, strerror(errno));
+			ret = -EIO;
+			break;
+		}
+
+		bytes += len;
+	}
+
+	printf("nandtool_dump: Written %lld bytes to %s file\n", bytes, outpath);
+
+	close(outfd);
+	free(buf);
+
+	return ret;
+}
+
+
 static void nandtool_help(const char *prog)
 {
 	printf("Usage: %s [options] <device>\n", prog);
-	printf("\t-e <start[:size]> - erase size block(s) starting from start\n");
+	printf("\t-e <start[:size]> - erase size block(s) starting from start or from the beginning if start arg is not provided\n");
 	printf("\t                    (skip size to erase one block or pass size=0 to erase whole device)\n");
 	printf("\t-j                - write jffs2 cleanmarkers (valid only with erase operation)\n");
 	printf("\t-c                - check device for bad blocks and print summary\n");
+	printf("\n");
+	printf("\t-d <start[:size]> - dump size blocks starting from start or from the beginning if start arg is not provided, requires -o\n");
+	printf("\t                    (skip size to dump one block or pass size=0 to dump everything until the end of a partition)\n");
+	printf("\t-o <path>         - path of the file to dump data\n");
+	printf("\t-b                - dump out-of-bound data (raw reads)\n");
 	printf("\n");
 	printf("\t-i <path>         - path of the file to flash (requires -s option)\n");
 	printf("\t-r                - flash raw data\n");
@@ -193,30 +296,71 @@ static void nandtool_help(const char *prog)
 }
 
 
+static int nandtool_parseRange(const char *str, int *start, int *size)
+{
+	char *endptr;
+
+	*start = strtoul(str, &endptr, 0);
+	if (*endptr == '\0') {
+		/* Default case, one block */
+		*size = 1;
+	}
+	else if (*endptr == ':') {
+		str = endptr + 1;
+		*size = strtoul(str, &endptr, 0);
+		if ((str == endptr) || (*endptr != '\0')) {
+			return -1;
+		}
+	}
+	else {
+		return -1;
+	}
+
+	return 0;
+}
+
+
 int main(int argc, char **argv)
 {
 	int check = 0, raw = 0, flash_start = -1, erase_start = -1, erase_size = -1, write_cleanmarkers = 0;
-	char *dev, *tok, *path = NULL;
+	int dump_start = -1, dump_size = -1, oob = 0;
+	const char *ipath = NULL, *opath = NULL;
+	char *dev;
 	int c, err;
 
 	if (isatty(STDOUT_FILENO))
 		nandtool_common.interactive = 1;
 
-	while ((c = getopt(argc, argv, "e:i:r:s:chjq")) != -1) {
+	while ((c = getopt(argc, argv, "e:d:i:o:rs:bchjq")) != -1) {
 		switch (c) {
 			case 'e':
-				tok = strtok(optarg, ":");
-				erase_start = strtoul(tok, NULL, 0);
-				erase_size = ((tok = strtok(NULL, ":")) == NULL) ? 1 : strtoul(tok, NULL, 0);
+				if (nandtool_parseRange(optarg, &erase_start, &erase_size) < 0) {
+					fprintf(stderr, "nandtool: Fail to parse erase args!\n");
+					return 1;
+				}
+				break;
+
+			case 'd':
+				if (nandtool_parseRange(optarg, &dump_start, &dump_size) < 0) {
+					fprintf(stderr, "nandtool: Fail to parse dump args!\n");
+					return 1;
+				}
 				break;
 
 			case 'j':
 				write_cleanmarkers = 1;
 				break;
 
+			case 'o':
+				opath = optarg;
+				break;
+
 			case 'i':
-				path = optarg;
-				raw = 0;
+				ipath = optarg;
+				break;
+
+			case 'b':
+				oob = 1;
 				break;
 
 			case 'r':
@@ -282,9 +426,13 @@ int main(int argc, char **argv)
 		if ((erase_start >= 0) && (erase_size >= 0) && ((err = nandtool_erase(erase_start, erase_size, write_cleanmarkers)) < 0))
 			break;
 
-		if ((flash_start >= 0) && (path != NULL) && ((err = nandtool_flash(path, flash_start, raw)) < 0))
+		if ((flash_start >= 0) && (ipath != NULL) && ((err = nandtool_flash(ipath, flash_start, raw)) < 0))
 			break;
 	} while (0);
+
+	if ((dump_start >= 0) && (opath != NULL)) {
+		nandtool_dump(opath, dump_start, dump_size, oob);
+	}
 
 	close(nandtool_common.fd);
 


### PR DESCRIPTION
JIRA: DTR-351

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This change allows dumping either raw or normal blocks to an output file. An example command used to dump 3 blocks of data including OOB data:
`nandtool -d 476:3 -o dump.bin -b /dev/mtd0p6`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is needed for debugging reasons.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imx6ull).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
