### PR TITLE
psh: Fix prompt eating last line if no \n was present

### DIFF
--- a/psh/pshapp/pshapp.c
+++ b/psh/pshapp/pshapp.c
@@ -615,7 +615,7 @@ static int psh_readcmd(struct termios *orig, psh_hist_t *cmdhist, char **cmd)
 						qsort(files, nfiles, sizeof(char *), psh_cmpname);
 						if ((err = psh_printfiles(files, nfiles)) < 0)
 							break;
-						write(STDOUT_FILENO, "\r\033[0J", 5);
+						write(STDOUT_FILENO, "\033[0J", 4);
 						write(STDOUT_FILENO, PROMPT, sizeof(PROMPT) - 1);
 						if (hp == cmdhist->he)
 							write(STDOUT_FILENO, *cmd, n + m);
@@ -651,7 +651,7 @@ static int psh_readcmd(struct termios *orig, psh_hist_t *cmdhist, char **cmd)
 			/* FF => clear screen */
 			else if (c == '\014') {
 				write(STDOUT_FILENO, "\033[f", 3);
-				write(STDOUT_FILENO, "\r\033[0J", 5);
+				write(STDOUT_FILENO, "\033[0J", 4);
 				write(STDOUT_FILENO, PROMPT, sizeof(PROMPT) - 1);
 				if (hp != cmdhist->he)
 					psh_printhistent(cmdhist->entries + hp);
@@ -722,7 +722,7 @@ static int psh_readcmd(struct termios *orig, psh_hist_t *cmdhist, char **cmd)
 					if (hp == cmdhist->he)
 						ln = n + m;
 					psh_movecursor(n + sizeof(PROMPT) - 1, -(n + sizeof(PROMPT) - 1));
-					write(STDOUT_FILENO, "\r\033[0J", 5);
+					write(STDOUT_FILENO, "\033[0J", 4);
 					write(STDOUT_FILENO, PROMPT, sizeof(PROMPT) - 1);
 					psh_printhistent(cmdhist->entries + (hp = (hp) ? hp - 1 : HISTSZ - 1));
 					n = cmdhist->entries[hp].n;
@@ -732,7 +732,7 @@ static int psh_readcmd(struct termios *orig, psh_hist_t *cmdhist, char **cmd)
 			else if (k == kDown) {
 				if (hp != cmdhist->he) {
 					psh_movecursor(n + sizeof(PROMPT) - 1, -(n + sizeof(PROMPT) - 1));
-					write(STDOUT_FILENO, "\r\033[0J", 5);
+					write(STDOUT_FILENO, "\033[0J", 4);
 					write(STDOUT_FILENO, PROMPT, sizeof(PROMPT) - 1);
 					if ((hp = (hp + 1) % HISTSZ) == cmdhist->he) {
 						n = ln;
@@ -1073,7 +1073,7 @@ static int psh_run(int exitable, const char *console)
 	pshapp_common.cmdhist = cmdhist;
 
 	while (pgrp == tcgetpgrp(STDIN_FILENO)) {
-		write(STDOUT_FILENO, "\r\033[0J", 5);
+		write(STDOUT_FILENO, "\033[0J", 4);
 		write(STDOUT_FILENO, PROMPT, sizeof(PROMPT) - 1);
 
 		if ((n = psh_readcmd(&orig, cmdhist, &cmd)) < 0) {


### PR DESCRIPTION
DONE: RTOS-303

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic-qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
