### PR TITLE
psh: Add `tty` command

### DIFF
--- a/psh/Makefile
+++ b/psh/Makefile
@@ -19,8 +19,9 @@ LOCAL_CFLAGS += -DPSH_SYSEXECWL='"$(PSH_SYSEXECWL)"'
 LOCAL_LDFLAGS := -z stack-size=4096 -z noexecstack
 
 # TODO: search for dirs?
-PSH_ALLCOMMANDS := bind cat cd cp date df dmesg echo edit exec hm kill ls mem mkdir mount \
-nc nslookup ntpclient perf ping pm ps pwd reboot runfile sync sysexec top touch umount uptime wget
+PSH_ALLCOMMANDS := bind cat cd cp date df dmesg echo edit exec hm kill ls \
+mem mkdir mount nc nslookup ntpclient perf ping pm ps pwd reboot runfile \
+sync sysexec top touch tty umount uptime wget
 PSH_COMMANDS ?= $(PSH_ALLCOMMANDS)
 PSH_APPLETS := pshapp help $(filter $(PSH_ALLCOMMANDS), $(PSH_COMMANDS))
 

--- a/psh/psh.h
+++ b/psh/psh.h
@@ -28,6 +28,7 @@ typedef struct psh_app {
 
 typedef struct {
 	psh_appentry_t *pshapplist;
+	char *ttydev;
 	volatile unsigned char sigint;  /* Received SIGINT */
 	volatile unsigned char sigquit; /* Received SIGQUIT */
 	volatile unsigned char sigstop; /* Received SIGTSTP */

--- a/psh/pshapp/pshapp.c
+++ b/psh/pshapp/pshapp.c
@@ -1021,11 +1021,11 @@ static int psh_run(int exitable, const char *console)
 
 	/* Time for klog to print data from buffer */
 	usleep(500000);
-	psh_ttyopen(console);
 
-	/* Check if we run interactively */
-	if (!isatty(STDIN_FILENO))
-		return -ENOTTY;
+	err = psh_ttyopen(console);
+	if (err < 0) {
+		return err;
+	}
 
 	/* Wait till we run in foreground */
 	if (tcgetpgrp(STDIN_FILENO) != -1) {

--- a/psh/tty/tty.c
+++ b/psh/tty/tty.c
@@ -1,0 +1,79 @@
+/*
+ * Phoenix-RTOS
+ *
+ * tty - print or replace interactive shell tty device
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Gerard Swiderski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <termios.h>
+#include <unistd.h>
+
+#include "../psh.h"
+
+
+static void psh_ttyInfo(void)
+{
+	printf("print or replace interactive shell tty device");
+}
+
+
+static int psh_ttyMain(int argc, char **argv)
+{
+	int ret;
+	pid_t pgrp;
+
+	if (psh_common.ttydev == NULL) {
+		fprintf(stderr, "psh: cannot run standalone\n");
+		return -EINVAL;
+	}
+
+	if (argc < 2) {
+		printf("%s\n", psh_common.ttydev);
+		return EOK;
+	}
+
+	if (argv[1][0] == '-' && argv[1][1] == 'h') {
+		printf("Usage: tty [/dev/console]\n");
+		return EOK;
+	}
+
+	pgrp = getpid();
+	if (pgrp < 0) {
+		fprintf(stderr, "psh: tty invalid pid\n");
+		return -EINVAL;
+	}
+
+	printf("Changing psh tty device '%s' to '%s'\n", psh_common.ttydev, argv[1]);
+
+	ret = psh_ttyopen(argv[1]);
+	if (ret < 0) {
+		fprintf(stderr, "psh: unable to change tty device to %s\n", argv[1]);
+		return ret;
+	}
+
+	if (tcsetpgrp(STDIN_FILENO, pgrp) < 0) {
+		/* TODO: handle this as fatal error due to dup2() in psh_ttyopen() */
+		fprintf(stderr, "psh: failed to set terminal control\n");
+		return -errno;
+	}
+
+	return EOK;
+}
+
+
+void __attribute__((constructor)) tty_registerapp(void)
+{
+	static psh_appentry_t app = { .name = "tty", .run = psh_ttyMain, .info = psh_ttyInfo };
+	psh_registerapp(&app);
+}


### PR DESCRIPTION
This change introduces the `tty` command which allow to change the current working terminal device or print tty device name (a path) to which `psh` standard I/O is currently connected.

The `tty` command is protected against using the wrong `tty` device and so that for example on`ia32` one does not mistakenly redirect the output to the hard disk `/dev/hda`:

![2023-02-21-122454_1126x354_scrot](https://user-images.githubusercontent.com/141153/220332808-076df551-7b49-42a7-9515-7a27e2162328.png)

**Example work flow** 
(two tty devices primary `/dev/console` alias `/dev/uart11`, and auxiliary`/dev/uart12`):

On `/dev/console` (print current connected tty device):
```
(psh)% tty
/dev/console
(psh)% _
```

On `/dev/console` (change to aux uart port `/dev/uart12`):
```
(psh)% tty /dev/uart12
Changing psh tty device '/dev/console' to '/dev/uart12'
_
```

Console prompt moved to `/dev/uart12`, to verify print `tty` device name:
```
(psh)% tty
/dev/uart12
(psh)% _
```

JIRA: RTOS-371

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic{pc-rry + uart16550}, nil-imxrt1176, mimxrt1064-evk).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/libphoenix/pull/234
- [ ] I will merge this PR by myself when appropriate.
