### PR TITLE
edit: fix attribute reset after cursor pos restore

### DIFF
--- a/psh/edit/edit.c
+++ b/psh/edit/edit.c
@@ -753,7 +753,7 @@ static void edit_drawStatusBar(int force)
 
 	fprintf(stdout, "\033[%d;%dH%s", edit_common.rows + 1, edit_common.cols - len, buf);
 
-	fprintf(stdout, "\033[0m\0338");
+	fprintf(stdout, "\0338\033[0m");
 }
 
 
@@ -788,7 +788,7 @@ static void edit_drawKeys(int force)
 			len += fprintf(stdout, "|");
 	}
 
-	fprintf(stdout, "\033[0K\033[0m\0338");
+	fprintf(stdout, "\033[0K\0338\033[0m");
 }
 
 


### PR DESCRIPTION
Cursor position and attributes are saved with `ESC 7` and restored with `ESC 8`, color and text attribute reset `ESC [ 0 m` must be done right after restoring the cursor context to take effect, otherwise the then saved context is restored will overwrite what we reset with the restored cursor context, easy.

This change is connected with https://github.com/phoenix-rtos/phoenix-rtos-devices/pull/350 pull-request, but may be merged independently.

JIRA: RTOS-378

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic, imxrt1176-evk, imxrt1064-evk, stm32l4a6-nucleo).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
