### PR TITLE
Allow either `dec` or `hex` values for parameters in cm4-tool

### DIFF
--- a/cm4-tool/tool.c
+++ b/cm4-tool/tool.c
@@ -99,11 +99,11 @@ int main(int argc, char *argv[])
 
 		case 't':
 			terminal = 1;
-			termno = (int)strtol(optarg, NULL, 10);
+			termno = (int)strtol(optarg, NULL, 0);
 			break;
 
 		case 'o':
-			offset = (unsigned int)strtol(optarg, NULL, 10);
+			offset = (unsigned int)strtol(optarg, NULL, 0);
 			break;
 
 		default:


### PR DESCRIPTION
quickfix: Allow values for parameters (e.g. offset/address for vector table) to be specified as decimal or hexadecimal value.

JIRA: RTOS-457

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imxrt1176-nil.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
