### PR TITLE
psh: implement command to `reset` terminal

### DIFF
--- a/psh/dmesg/dmesg.c
+++ b/psh/dmesg/dmesg.c
@@ -38,7 +38,7 @@ static void psh_dmesg_help(const char *prog)
 int psh_dmesg(int argc, char **argv)
 {
 	char buf[256];
-	int n, written, ret;
+	int n;
 	int c, fd;
 
 	while ((c = getopt(argc, argv, "h")) != -1) {
@@ -65,19 +65,9 @@ int psh_dmesg(int argc, char **argv)
 				break;
 			}
 		}
-		written = 0;
-		while (written < n) {
-			ret = write(STDOUT_FILENO, buf + written, n - written);
-			if (ret > 0) {
-				written += ret;
-			}
-			else if (errno == EINTR) {
-				continue;
-			}
-			else {
-				close(fd);
-				return 1;
-			}
+		if (psh_write(STDOUT_FILENO, buf, n) != n) {
+			close(fd);
+			return 1;
 		}
 	}
 	close(fd);

--- a/psh/edit/edit.c
+++ b/psh/edit/edit.c
@@ -106,13 +106,9 @@ enum {
 };
 
 
-static ssize_t term_print(const char *str)
+static void term_print(const char *str)
 {
-	size_t len = 0;
-	while (str[len] != '\0')
-		len++;
-
-	return write(STDOUT_FILENO, str, len);
+	(void)psh_write(STDOUT_FILENO, str, strlen(str));
 }
 
 

--- a/psh/nc/nc.c
+++ b/psh/nc/nc.c
@@ -174,7 +174,7 @@ static int psh_nc_sockstreamListen(int sfd, int socktype, struct sockaddr *socka
 					fprintf(stderr, "nc: Can't receive msg!\n");
 					return -1;
 				}
-				write(STDOUT_FILENO, buf, c);
+				(void)psh_write(STDOUT_FILENO, buf, c);
 
 				if ((connect(sfd, (struct sockaddr *) &sin, raddrlen)) < 0) {
 					fprintf(stderr, "nc: Fail to connect!\n");
@@ -217,7 +217,7 @@ static void psh_nc_socktalk(int fd)
 		if (FD_ISSET(fd, &fds)) {
 			if ((n = recv(fd, buf, sizeof(buf), 0)) <= 0)
 				return;
-			write(STDOUT_FILENO, buf, n);
+			(void)psh_write(STDOUT_FILENO, buf, n);
 			memset(buf, 0, n);
 		}
 	}

--- a/psh/psh.c
+++ b/psh/psh.c
@@ -88,6 +88,29 @@ static char *psh_stralloc(char *oldstr, const char *str)
 }
 
 
+size_t psh_write(int fd, const void *buf, size_t count)
+{
+	ssize_t res;
+	size_t len = 0;
+
+	while (len != count) {
+		res = write(fd, (const uint8_t *)buf + len, count - len);
+		if (res <= 0) {
+			if ((errno == EINTR) || (errno == EAGAIN)) {
+				continue;
+			}
+			break;
+		}
+		else {
+			len += (size_t)res;
+		}
+	}
+
+	/* on error: (len != count) and errno is set */
+	return len;
+}
+
+
 int psh_ttyopen(const char *ttydev)
 {
 	char *newPath;

--- a/psh/psh.h
+++ b/psh/psh.h
@@ -62,6 +62,9 @@ extern const psh_appentry_t *psh_applist_first(void);
 extern const psh_appentry_t *psh_applist_next(const psh_appentry_t *current);
 
 
+extern size_t psh_write(int fd, const void *buf, size_t count);
+
+
 extern int psh_ttyopen(const char *dev);
 
 


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->

The `reset` command in the `psh` console is used to restore the settings of the terminal (to cooked, non-raw mode) after some program terminates abnormally leaving e.g. hidden text cursor or termios in raw mode.  The reset command works by performing the following operations:
* clear the screen,
* restore cursor mode and terminal settings 

The `clear` command clears the screen without clearing the scrollback buffer (works like `CTRL+L`, but may be called from psh script).

These commands are internal (builtin commands) to pshapp command interpreter (commands should not be in `/bin` path).

In real environment (big targets), `reset` is implemented by [`tset`](https://man.openbsd.org/reset) which is a dedicated terminal settings management tool.

Additionally `write()` function is being replaced by safe write implementation `psh_write()`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

JIRA: RTOS-561

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imxrt1176-nil`, `ia32-generic (VGA and uart console)`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/240
https://github.com/phoenix-rtos/phoenix-rtos-project/pull/799
- [ ] I will merge this PR by myself when appropriate.
