### PR TITLE
psh/ping: fix filtering correct reply packet

### DIFF
--- a/psh/psh.h
+++ b/psh/psh.h
@@ -20,8 +20,8 @@
 
 typedef struct psh_app {
 	const char name[11];
-	const int (*run)(int argc, char **argv);
-	const void (*info)(void);
+	int (*const run)(int argc, char **argv);
+	void (*const info)(void);
 	struct psh_app *next;
 } psh_appentry_t;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Filter incoming ICPM messages:
- by type (parse only ECHOREPLY) - fixes `ping 127.0.0.1`
- by ID - fixes concurrent pings

## Motivation and Context

Fixes: phoenix-rtos/phoenix-rtos-project#826

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
