### PR TITLE
psh: print year in `ls -l` command if different from current

### DIFF
--- a/psh/ls/ls.c
+++ b/psh/ls/ls.c
@@ -269,6 +269,12 @@ static void psh_ls_printlong(size_t nfiles)
 	int daysz = 1;
 	unsigned int i, j;
 	struct tm t;
+	int currentYear = 0;
+	time_t currentTime = time(NULL);
+
+	if (localtime_r(&currentTime, &t) != NULL) {
+		currentYear = t.tm_year;
+	}
 
 	for (i = 0; i < nfiles; i++) {
 		linksz = max(psh_ls_numplaces(files[i].stat.st_nlink), linksz);
@@ -326,7 +332,12 @@ static void psh_ls_printlong(size_t nfiles)
 		localtime_r(&files[i].stat.st_mtime, &t);
 		strftime(buff, 80, "%b ", &t);
 		sprintf(buff + 4, "%*d ", daysz, t.tm_mday);
-		strftime(buff + 5 + daysz, 75 - daysz, "%H:%M", &t);
+		if (t.tm_year == currentYear) {
+			strftime(buff + 5 + daysz, 75 - daysz, "%H:%M", &t);
+		}
+		else {
+			snprintf(buff + 5 + daysz, 75 - daysz, "%5d", t.tm_year + 1900);
+		}
 
 		printf("%s %*d ", perms, linksz, files[i].stat.st_nlink);
 		printf("%-*s ", usersz, (files[i].pw != NULL) ? files[i].pw->pw_name : "---");


### PR DESCRIPTION
## Description
`ls -l` command now prints the modification year of the file if the year is different from the current year. 
Before:
```sh
(psh)% date
Thu, 01 Jan 70 00:00:02
(psh)% ls -l
[...]
drwxrwxr-x  6 ---  ---   1024 Sep 18 11:59 usr
drwxrwxr-x  3 ---  ---   1024 Jan  1 00:00 var
```
After:
```sh
(psh)% date
Thu, 01 Jan 70 00:00:02
(psh)% ls -la
[...]
drwxrwxr-x  6 --- ---   1024 Sep 18  2023 usr
drwxrwxr-x  3 --- ---   1024 Jan  1 00:00 var

```
This behavior is consistent with other implementations of `ls`, for example in Bash.

## Motivation and Context
Fixes issue https://github.com/phoenix-rtos/phoenix-rtos-project/issues/552

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Some scripts (in particular tests) assume that the command always prints modification time.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.

https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/260 needs to be merged first in order for tests to pass.