### PR TITLE
psh: printf prompt after entering raw mode

### DIFF
--- a/psh/pshapp/pshapp.c
+++ b/psh/pshapp/pshapp.c
@@ -499,9 +499,6 @@ static int psh_keyCode(const char *buff, int *pEsc)
 }
 
 
-extern void cfmakeraw(struct termios *termios);
-
-
 static int psh_readcmd(struct termios *orig, psh_hist_t *cmdhist, char **cmd)
 {
 	int i, k, nfiles, err = 0, esc = 0, n = 0, m = 0, ln = 0, hp = cmdhist->he;
@@ -522,6 +519,8 @@ static int psh_readcmd(struct termios *orig, psh_hist_t *cmdhist, char **cmd)
 		free(*cmd);
 		return err;
 	}
+
+	write(STDOUT_FILENO, "\033[0J" PROMPT, 4 + sizeof(PROMPT) - 1);
 
 	for (;;) {
 		read(STDIN_FILENO, &c, 1);
@@ -1084,9 +1083,6 @@ static int psh_run(int exitable, const char *console)
 	pshapp_common.cmdhist = cmdhist;
 
 	while (pgrp == tcgetpgrp(STDIN_FILENO)) {
-		write(STDOUT_FILENO, "\033[0J", 4);
-		write(STDOUT_FILENO, PROMPT, sizeof(PROMPT) - 1);
-
 		if ((n = psh_readcmd(&orig, cmdhist, &cmd)) < 0) {
 			err = n;
 			break;


### PR DESCRIPTION
JIRA: RTOS-625

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
Previously there was a timeframe in which entered command could be duplicated by echo of tty console in cannonical mode leading to issues in CI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
