### PR TITLE
psh/dd: fix printing statistics to stderr

### DIFF
--- a/psh/dd/dd.c
+++ b/psh/dd/dd.c
@@ -421,11 +421,11 @@ static int psh_dd(int argc, char **argv)
 
 	free(buf);
 
-	printf("%zu+%d records in\n",
+	fprintf(stderr, "%zu+%d records in\n",
 		(size_t)(intotal / blocksz),
 		(int)(intotal % blocksz) != 0);
 
-	printf("%zu+%d records out\n",
+	fprintf(stderr, "%zu+%d records out\n",
 		(size_t)(outtotal / blocksz),
 		(int)(outtotal % blocksz) != 0);
 


### PR DESCRIPTION
Statistics `records in and out` coount was printed to stdout instead of stderr.
This PR fixes that.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
