### PR TITLE
psh: close directory after listing

### DIFF
--- a/psh/pshapp/pshapp.c
+++ b/psh/pshapp/pshapp.c
@@ -365,6 +365,10 @@ static int psh_completepath(char *dir, char *base, char ***files)
 		}
 	} while (0);
 
+	if (stream != NULL) {
+		closedir(stream);
+	}
+
 	if (err < 0) {
 		for (i = 0; i < nfiles; i++)
 			free((*files)[i]);


### PR DESCRIPTION
In function `psh_completepath` directory handle was not closed after listing the directory. This led to a resource leak every time the path completion feature was used. This PR fixes the resource leak.

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
