### PR TITLE
psh: fix ifconfig ub in interface print flags

### DIFF
--- a/psh/ifconfig/ifconfig.c
+++ b/psh/ifconfig/ifconfig.c
@@ -29,7 +29,13 @@
 #define IFCONFIG_ALL     2
 #define IFCONFIG_HELP    4
 
-enum operation {operation_setFlag, operation_unsetFlag, operation_toggleFlag};
+
+/* clang-format off */
+
+enum operation { operation_setFlag, operation_unsetFlag, operation_toggleFlag };
+
+/* clang-format on */
+
 
 static void psh_ifconfigInfo(void)
 {
@@ -97,7 +103,7 @@ static inline int psh_ifconfigPrintInterface(const struct ifaddrs *interface, in
 		perror("ioctl(SIOCGIFFLAGS)");
 		return ret;
 	}
-	interfaceFlags = ioctlInterface.ifr_flags;
+	interfaceFlags = (unsigned short)ioctlInterface.ifr_flags; /* ifr_flags is signed short */
 
 	printf("Link encap:");
 	switch (interfaceFlags & (IFF_LOOPBACK | IFF_POINTOPOINT)) {
@@ -169,11 +175,11 @@ static inline int psh_ifconfigPrintInterface(const struct ifaddrs *interface, in
 	}
 	printf("Mask:%s\n", msg);
 
-	if (interfaceFlags != 0) {
+	if (interfaceFlags != 0u) {
 		printf("%10s", "");
-		for (i = 1; i <= interfaceFlags; i <<= 1) {
-			if ((interfaceFlags & i) != 0) {
-				printf("%s ", psh_ifconfigPrintFlag(i));
+		for (i = 0u; i < sizeof(ioctlInterface.ifr_flags) * 8u; ++i) {
+			if ((interfaceFlags & (1u << i)) != 0u) {
+				printf("%s ", psh_ifconfigPrintFlag(1u << i));
 			}
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

`interfaceFlags` is of type `unsigned int` (good for maintaining IPv6 compatibility with `ifr_flags6`), but currently `ifr_flags` in ipv4 is used, which is of type `short`. When assigning the `IFF_DYNAMIC=0x8000` flag, the sign is expanded to an integer (0xffff8000), which, if used as an upper limit in a loop shifting left through bits of the `interfaceFlags` variable, causes undefined behavior in the loop condition, which results in overflow in the loop, which `leads to its infinite iteration`.

JIRA: RTOS-695

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
