### PR TITLE
psh/ifconfig: add trigger to activate dhcp client

### DIFF
--- a/psh/ifconfig/ifconfig.c
+++ b/psh/ifconfig/ifconfig.c
@@ -419,6 +419,15 @@ static int psh_ifconfigArp(struct ifreq *ioctlInterface, int sd, int argc, char 
 }
 
 
+static int psh_ifconfigDynamic(struct ifreq *ioctlInterface, int sd, int argc, char **argv, int *opt)
+{
+	(void)argc;
+	(void)argv;
+	(void)opt;
+	return psh_ifconfigChangeFlag(ioctlInterface, sd, IFF_DYNAMIC, operation_toggleFlag);
+}
+
+
 static const struct {
 	const char *name;
 	int (*handler)(struct ifreq *ioctlInterface, int sd, int argc, char **argv, int *opt);
@@ -440,6 +449,8 @@ static const struct {
 	{ .name = "-promisc", .handler = psh_ifconfigPromisc, .helpDescription = NULL },
 	{ .name = "arp", .handler = psh_ifconfigArp, .helpDescription = "[-]arp: Toggle arp flag" },
 	{ .name = "-arp", .handler = psh_ifconfigArp, .helpDescription = NULL },
+	{ .name = "dynamic", .handler = psh_ifconfigDynamic, .helpDescription = "[-]dynamic: Toggle activation of DHCP client" },
+	{ .name = "-dynamic", .handler = psh_ifconfigDynamic, .helpDescription = NULL },
 };
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

It is possible to invoke a `dynamic address` on network interface using `LwIP's built-in DHCP client` by setting the `IFF_DYNAMIC` flag. Accordingly, setting or clearing this flag on the interface supporting this property (e.g. `ethernet`) activates or deactivates the DHCP client.

Activating and deactivating dhcp:
![2023-11-29-204540_1528x590_scrot](https://github.com/phoenix-rtos/phoenix-rtos-utils/assets/141153/09f61669-9eb1-479e-a4bb-2f7f8725664c)

JIRA: RTOS-696

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Automatic address assignment in qemu (with its DHCP server).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `ia32-generic`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
