### PR TITLE
psh/hd: Introduce hexdump utility

### DIFF
--- a/psh/Makefile
+++ b/psh/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile for Phoenix-RTOS psh (Phoenix SHell)
 #
-# Copyright 2018-2024 Phoenix Systems
+# Copyright 2018-2023 Phoenix Systems
 #
 
 NAME := psh
@@ -19,7 +19,7 @@ LOCAL_CFLAGS += -DPSH_SYSEXECWL='"$(PSH_SYSEXECWL)"'
 LOCAL_LDFLAGS := -z stack-size=4096 -z noexecstack
 
 # TODO: search for dirs?
-PSH_ALLCOMMANDS := bind cat cd chmod cp date dd df dmesg echo edit exec hm \
+PSH_ALLCOMMANDS := bind cat cd chmod cp date dd df dmesg echo edit exec hm hd \
 ifconfig kill ln ls mem mkdir mount nc nslookup ntpclient perf ping pm printenv \
 ps pwd reboot rm rmdir runfile route sync sysexec top touch tty umount uptime wget
 PSH_COMMANDS ?= $(PSH_ALLCOMMANDS)

--- a/psh/hd/hd.c
+++ b/psh/hd/hd.c
@@ -1,0 +1,176 @@
+/*
+ * Phoenix-RTOS
+ *
+ * hd - prints file contents in hexadecimal and ascii representation
+ *
+ * Copyright 2024 Phoenix Systems
+ * Author: Gerard Swiderski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <errno.h>
+#include <ctype.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/minmax.h>
+#include <sys/stat.h>
+
+#include "../psh.h"
+
+#define LINE_WIDTH 16u
+
+
+static void psh_hd_info(void)
+{
+	printf("dumps file contents in hexadecimal and ascii representation");
+}
+
+
+static void psh_hd_usage(const char *name)
+{
+	printf("Usage: %s -s offset -n length [filename]\n", name);
+}
+
+
+static void psh_hexdump(const uint8_t *data, size_t ofs, size_t len)
+{
+	while (len != 0u) {
+		size_t toprint = min(len, LINE_WIDTH);
+
+		printf("%08zx ", (size_t)ofs);
+
+		for (size_t i = 0u; i < toprint; i++) {
+			printf(((i & 7u) == 0u) ? " %02x " : "%02x ", data[i]);
+		}
+
+		for (size_t i = toprint; i < LINE_WIDTH; i++) {
+			printf(((i & 7u) == 0u) ? "    " : "   ");
+		}
+
+		printf(" |");
+
+		for (size_t i = 0u; i < toprint; i++) {
+			printf("%c", (isprint(data[i]) != 0) ? (int)data[i] : (int)'.');
+		}
+
+		puts("|");
+
+		data += toprint;
+		ofs += toprint;
+		len -= toprint;
+	}
+}
+
+
+static int psh_hd(int argc, char **argv)
+{
+	uint8_t buffer[2u * LINE_WIDTH];
+	struct stat st;
+	char *filename = NULL;
+	size_t len = SIZE_MAX;
+	off_t ofs = 0;
+
+	for (;;) {
+		char *ptr = NULL;
+		int opt = getopt(argc, argv, "hn:s:");
+		if (opt == -1) {
+			break;
+		}
+		switch (opt) {
+			case 's':
+				ofs = strtoul(optarg, &ptr, 0);
+				break;
+
+			case 'n':
+				len = strtoul(optarg, &ptr, 0);
+				break;
+
+			case 'h':
+				psh_hd_usage(argv[0]);
+				return EXIT_SUCCESS;
+
+			default:
+				psh_hd_usage(argv[0]);
+				return EXIT_FAILURE;
+		}
+
+		if ((optarg == ptr) || ((ptr != NULL) && ((*ptr != '\0') || (isdigit(*optarg) == 0)))) {
+			fprintf(stderr, "%s: invalid value\n", argv[0]);
+			return EXIT_FAILURE;
+		}
+	}
+
+	if (optind < argc) {
+		filename = argv[optind];
+	}
+
+	if (len != 0u) {
+		int fd = (filename != NULL) ? open(filename, O_RDONLY) : STDIN_FILENO;
+		filename = (filename != NULL) ? filename : "stdin";
+
+		if ((fd < 0)) {
+			fprintf(stderr, "%s: %s: %s\n", argv[0], filename, strerror(errno));
+			return EXIT_FAILURE;
+		}
+
+		if ((fstat(fd, &st) == 0) && (S_ISDIR(st.st_mode) != 0)) {
+			fprintf(stderr, "%s: %s: %s\n", argv[0], filename, strerror(EISDIR));
+			return EXIT_FAILURE;
+		}
+
+		if (ofs > 0) {
+			if (lseek(fd, ofs, SEEK_SET) < 0) {
+				fprintf(stderr, "%s: %s\n", argv[0], strerror(errno));
+				if (fd != STDIN_FILENO) {
+					close(fd);
+				}
+				return EXIT_FAILURE;
+			}
+		}
+
+		while ((len != 0u) && (psh_common.sigint == 0u)) {
+			ssize_t toprint = read(fd, buffer, (size_t)min(len, sizeof(buffer)));
+
+			if (toprint <= 0) {
+				if (toprint == 0) {
+					break;
+				}
+				if ((errno == EAGAIN) || (errno == EINTR)) {
+					continue;
+				}
+				else {
+					fprintf(stderr, "%s: %s\n", argv[0], strerror(errno));
+					break;
+				}
+			}
+
+			psh_hexdump(buffer, (size_t)ofs, (size_t)toprint);
+
+			ofs += (off_t)toprint;
+			len -= (size_t)toprint;
+		}
+
+		if (ofs != 0) {
+			printf("%08zx\n", (size_t)ofs);
+		}
+
+		if (fd != STDIN_FILENO) {
+			close(fd);
+		}
+	}
+
+	return (len != 0u) ? EXIT_FAILURE : EXIT_SUCCESS;
+}
+
+
+static void __attribute__((constructor)) hd_registerapp(void)
+{
+	static psh_appentry_t app = { .name = "hd", .run = psh_hd, .info = psh_hd_info };
+	psh_registerapp(&app);
+}

--- a/psh/psh.c
+++ b/psh/psh.c
@@ -115,6 +115,29 @@ size_t psh_write(int fd, const void *buf, size_t count)
 }
 
 
+size_t psh_read(int fd, void *buf, size_t count)
+{
+	ssize_t res;
+	size_t len = 0;
+
+	while (len != count) {
+		res = read(fd, (uint8_t *)buf + len, count - len);
+		if (res <= 0) {
+			if ((errno == EINTR) || (errno == EAGAIN)) {
+				continue;
+			}
+			break;
+		}
+		else {
+			len += (size_t)res;
+		}
+	}
+
+	/* on error: (len != count) and errno is set */
+	return len;
+}
+
+
 int psh_ttyopen(const char *ttydev)
 {
 	char *newPath;

--- a/psh/psh.h
+++ b/psh/psh.h
@@ -65,6 +65,9 @@ extern const psh_appentry_t *psh_applist_next(const psh_appentry_t *current);
 extern size_t psh_write(int fd, const void *buf, size_t count);
 
 
+extern size_t psh_read(int fd, void *buf, size_t count);
+
+
 extern int psh_ttyopen(const char *dev);
 
 


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->

The `hd` tool introduced in this PR is used to dump the contents of files and read devices (if read is supported by driver) in the form of `hexdump`, quick examples of use are provided below.

### Usage:
```
(psh)% hd -h
Usage: hd -s offset -n length [filename]
```


### Examples:

text-file:
```
(psh)% hd /etc/platform 
00000000  69 61 33 32 0a                                    |ia32.|
00000005
```

32bytes of MBR:
```
(psh)% hd -n 32 /dev/hda
00000000  ea 05 7c 00 00 fa 31 c0  8e d8 8e c0 8e d0 bc 00  |..|...1.........|
00000010  70 fb 88 16 4f 7d bb aa  55 b4 41 cd 13 72 16 81  |p...O}..U.A..r..|
00000020

```

rand():
```
(psh)% hd -n 34 /dev/urandom
00000000  33 ac da 00 5e f8 d5 78  e6 f8 fc 58 a6 d1 89 06  |3...^..x...X....|
00000010  c3 c4 a2 53 a8 46 34 49  db 1c 4b 06 60 80 a7 6c  |...S.F4I..K.`..l|
00000020  bf ce                                             |..|
00000022
```

script user.plo on hdd
```
(psh)% hd -n 0x160 -s 0x12000 /dev/hda
00012000  62 61 61 64 66 30 30 64  0a 77 61 69 74 20 31 30  |baadf00d.wait 10|
00012010  30 30 0a 61 6c 69 61 73  20 70 68 6f 65 6e 69 78  |00.alias phoenix|
00012020  2d 69 61 33 32 2d 67 65  6e 65 72 69 63 2e 65 6c  |-ia32-generic.el|
00012030  66 20 30 78 31 33 30 30  30 20 30 78 32 62 30 30  |f 0x13000 0x2b00|
... cut ...
00012130  30 20 2d 78 20 70 63 2d  61 74 61 20 72 61 6d 20  |0 -x pc-ata ram |
00012140  72 61 6d 0a 67 6f 21 0a  00 00 00 00 00 00 00 00  |ram.go!.........|
00012150  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00012160
```

## Motivation and Context
Development, debugging tool-set.

JIRA: RTOS-110

<!--- Provide a general summary of your changes in the Title above -->
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `ia32-generic`, `imxrt1176`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
