### PR TITLE
psh: reimplement 'kill' command

### DIFF
--- a/psh/kill/kill.c
+++ b/psh/kill/kill.c
@@ -1,10 +1,11 @@
 /*
  * Phoenix-RTOS
  *
- * kill - send signal_kill to process
+ * kill - send a signal to a process
  *
- * Copyright 2017, 2018, 2020, 2021 Phoenix Systems
- * Author: Pawel Pisarczyk, Jan Sikorski, Maciej Purski, Lukasz Kosinski, Mateusz Niewiadomski
+ * Copyright 2017, 2018, 2020, 2021, 2024 Phoenix Systems
+ * Author: Pawel Pisarczyk, Jan Sikorski, Maciej Purski,
+ * Lukasz Kosinski, Mateusz Niewiadomski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -12,43 +13,121 @@
  */
 
 #include <errno.h>
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <sys/threads.h>
+#include <signal.h>
 
 #include "../psh.h"
 
 
-void psh_killinfo(void)
+static void psh_killInfo(void)
 {
-	printf("terminates process");
+	printf("sends a signal to a process");
 }
 
 
-int psh_kill(int argc, char **argv)
+static void killUsage(void)
 {
-	unsigned int pid;
+	puts("Usage: kill [-s signal | -signal] <pid [...]>");
+}
+
+
+static int signalByName(const char *name)
+{
+	static const struct {
+		const char *name;
+		int signal;
+	} sigNames[] = {
+		/* clang-format on */
+
+		{ "HUP", SIGHUP }, { "INT", SIGINT }, { "QUIT", SIGQUIT }, { "ILL", SIGILL },
+		{ "TRAP", SIGTRAP }, { "ABRT", SIGABRT }, { "EMT", SIGEMT }, { "FPE", SIGFPE },
+		{ "KILL", SIGKILL }, { "BUS", SIGBUS }, { "SEGV", SIGSEGV }, { "SYS", SIGSYS },
+		{ "PIPE", SIGPIPE }, { "ALRM", SIGALRM }, { "TERM", SIGTERM }, { "USR1", SIGUSR1 },
+		{ "USR2", SIGUSR2 }, { "CHLD", SIGCHLD }, { "WINCH", SIGWINCH }, { "URG", SIGURG },
+		{ "IO", SIGIO }, { "STOP", SIGSTOP }, { "TSTP", SIGTSTP }, { "CONT", SIGCONT },
+		{ "TTIN", SIGTTIN }, { "TTOU", SIGTTOU }, { "VTALRM", SIGVTALRM }, { "PROF", SIGPROF },
+		{ "XCPU", SIGXCPU }, { "XFSZ", SIGXFSZ }, { "INFO", SIGINFO }
+
+		/* clang-format off */
+	};
+
+	if ((name[0] == 'S') && (name[1] == 'I') && (name[2] == 'G')) {
+		name += 3;
+	}
+
+	for (size_t i = 0; i < sizeof(sigNames) / sizeof(sigNames[0]); ++i) {
+		if (strcmp(name, sigNames[i].name) == 0) {
+			return sigNames[i].signal;
+		}
+	}
+
+	return -1;
+}
+
+
+static int psh_killMain(int argc, char **argv)
+{
 	char *end;
+	int sigNo = SIGTERM;
+	int argn = 1;
 
-	if (argc != 2) {
-		fprintf(stderr, "usage: %s <pid>\n", argv[0]);
-		return -EINVAL;
+	if (argc <= argn) {
+		killUsage();
+		return EXIT_FAILURE;
 	}
 
-	pid = strtoul(argv[1], &end, 10);
-	if (*end != '\0') {
-		fprintf(stderr, "kill: could not parse process id: %s\n", argv[1]);
-		return -EINVAL;
+	if (argv[1][0] == '-') {
+		char *sigArg = argv[argn++] + 1;
+		if (argv[1][1] == 's') {
+			if ((argv[1][2] != '\0')) {
+				killUsage();
+				return EXIT_FAILURE;
+			}
+			sigArg = argv[argn++];
+		}
+		if ((argc <= argn) || (argv[1][1] == '-') || (argv[1][1] == '\0')) {
+			killUsage();
+			return EXIT_FAILURE;
+		}
+
+		unsigned long int signalValue = strtoul(sigArg, &end, 10);
+
+		if (*end == '\0') {
+			sigNo = (int)signalValue;
+		}
+		else {
+			sigNo = signalByName(sigArg);
+			if (sigNo < 0) {
+				fprintf(stderr, "kill: invalid signal name: %s\n", sigArg);
+				return EXIT_FAILURE;
+			}
+		}
 	}
 
-	return signalPost(pid, -1, signal_kill);
+	for (; argn < argc; ++argn) {
+		errno = 0;
+		pid_t pid = (pid_t)strtol(argv[argn], &end, 10);
+
+		if ((argv[argn][0] == '-') || (*end != '\0') || ((pid == 0) && (errno == EINVAL))) {
+			fprintf(stderr, "kill: invalid process id: %s\n", argv[argn]);
+			return EXIT_FAILURE;
+		}
+
+		if (kill(pid, sigNo) != 0) {
+			fprintf(stderr, "kill: failed to send signal to process %d\n", pid);
+			return EXIT_FAILURE;
+		}
+	}
+
+	return EXIT_SUCCESS;
 }
 
 
-void __attribute__((constructor)) kill_registerapp(void)
+static void __attribute__((constructor)) kill_registerapp(void)
 {
-	static psh_appentry_t app = {.name = "kill", .run = psh_kill, .info = psh_killinfo};
+	static psh_appentry_t app = { .name = "kill", .run = psh_killMain, .info = psh_killInfo };
 	psh_registerapp(&app);
 }


### PR DESCRIPTION
The commit with the title "WIP" will be removed, its purpose is to point out differences from the CI unit test.

## Description
<!--- Describe your changes shortly -->

The purpose of this change is to implement the `kill` command to accept a POSIX-compliant signal number or signal name, which then can be sent to one or more processes.

The  `default` `signal` for kill is `TERM`.

```
Usage: kill [-s signal | -signal] <pid [...]>
```

### Usage examples

send the default `TERM` signal to pids 14 15 20
`(psh)% kill 14 15 20`

Send a KILL signal (this was the behavior of the previous implementation of psh kill command)
`(psh)% kill -SIGKILL 10`
or
`(psh)% kill -KILL 10`
or
`(psh)% kill -9 10`

Some other examples
`(psh)% kill -SIGHUP 8`

`(psh)% kill -s SIGQUIT 9 10 11`


<!--- Provide a general summary of your changes in the Title above -->


## Motivation and Context

Sending signals to processes like `SIGUSR1`, `SIGQUIT`, `SIGHUP`.. not just single `signal_kill`.

JIRA: RTOS-760

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `ia32-generic`, `imxrt1176-evk`, `imxrt1064-g3evk`, `stm32l4a6-nucleo`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
