### PR TITLE
psh/mem: print shared map name

### DIFF
--- a/psh/mem/mem.c
+++ b/psh/mem/mem.c
@@ -300,7 +300,7 @@ static int psh_sharedMaps(void)
 			continue;
 		}
 
-		printf("\nMap #%d\n", info.maps.map[i].id);
+		printf("\nMap #%d: %s\n", info.maps.map[i].id, info.maps.map[i].name);
 		psh_bytes2humanReadable(buff, sizeof(buff), info.maps.map[i].alloc + info.maps.map[i].free);
 		printf("\tSize:     %s (%zu bytes)\n", buff, info.maps.map[i].alloc + info.maps.map[i].free);
 		psh_bytes2humanReadable(buff, sizeof(buff), info.maps.map[i].alloc);


### PR DESCRIPTION
`mem -s` command in psh now prints the map name, using the recently introduced feature in `meminfo` syscall.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imxrt117x

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
