### PR TITLE
psh: modify threadsinfo calls according to kernel changes

### DIFF
--- a/psh/bind/bind.c
+++ b/psh/bind/bind.c
@@ -39,17 +39,28 @@ int psh_bind(int argc, char **argv)
 		return -EINVAL;
 	}
 
-	if (lookup(argv[1], NULL, &soid) < 0)
+	err = lookup(argv[1], NULL, &soid);
+	if (err < 0) {
+		fprintf(stderr, "bind: lookup(source) = %d\n", err);
 		return -ENOENT;
+	}
 
-	if (lookup(argv[2], NULL, &doid) < 0)
+	err = lookup(argv[2], NULL, &doid);
+	if (err < 0) {
+		fprintf(stderr, "bind: lookup(target) = %d\n", err);
 		return -ENOENT;
+	}
 
-	if ((err = stat(argv[2], &buf)))
+	err = stat(argv[2], &buf);
+	if (err != 0) {
+		fprintf(stderr, "bind: stat failed with %d\n", err);
 		return err;
+	}
 
-	if (!S_ISDIR(buf.st_mode))
+	if (!S_ISDIR(buf.st_mode)) {
+		fprintf(stderr, "bind: target is not a directory\n");
 		return -ENOTDIR;
+	}
 
 	msg.type = mtSetAttr;
 	msg.oid = doid;
@@ -59,7 +70,16 @@ int psh_bind(int argc, char **argv)
 
 	err = msgSend(doid.port, &msg);
 
-	return (err < 0) ? err : msg.o.err;
+	if (err != 0) {
+		fprintf(stderr, "bind: msgSend failed with %d\n", err);
+		return err;
+	}
+	else if (msg.o.err != 0) {
+		fprintf(stderr, "bind: server responded with %d\n", msg.o.err);
+		return msg.o.err;
+	}
+
+	return EOK;
 }
 
 

--- a/psh/pm/pm.c
+++ b/psh/pm/pm.c
@@ -51,11 +51,15 @@ static int psh_pm_cmppid(const void *t1, const void *t2)
 
 static int psh_pm_getThreads(threadinfo_t **pinfo, int *n)
 {
-	int tcnt, m = *n;
+	int tcnt, m = *n, ret;
 	threadinfo_t *info = *pinfo, *rinfo;
 
 	if (info == NULL) {
+		ret = threadsinfo(PH_THREADINFO_THREADS_ALL, PH_THREADINFO_OPT_THREADCOUNT, 0, NULL);
 		m = 32;
+		if (ret * 2 > m) {
+			m = ret * 2;
+		}
 		info = malloc(m * sizeof(threadinfo_t));
 		if (info == NULL) {
 			fprintf(stderr, "pm: out of memory\n");
@@ -63,8 +67,8 @@ static int psh_pm_getThreads(threadinfo_t **pinfo, int *n)
 		}
 	}
 
-	while ((tcnt = threadsinfo(m, info)) >= m) {
-		m *= 2;
+	while ((tcnt = threadsinfo(PH_THREADINFO_THREADS_ALL, PH_THREADINFO_ALL, m, info)) >= m) {
+		m = tcnt * 2;
 		if ((rinfo = realloc(info, m * sizeof(threadinfo_t))) == NULL) {
 			fprintf(stderr, "pm: out of memory\n");
 			*pinfo = info;

--- a/psh/pm/pm.c
+++ b/psh/pm/pm.c
@@ -55,7 +55,7 @@ static int psh_pm_getThreads(threadinfo_t **pinfo, int *n)
 	threadinfo_t *info = *pinfo, *rinfo;
 
 	if (info == NULL) {
-		ret = threadsinfo(PH_THREADINFO_THREADS_ALL, PH_THREADINFO_OPT_THREADCOUNT, 0, NULL);
+		ret = threadsinfo(0, PH_THREADINFO_OPT_THREADCOUNT, NULL);
 		m = 32;
 		if (ret * 2 > m) {
 			m = ret * 2;
@@ -67,7 +67,7 @@ static int psh_pm_getThreads(threadinfo_t **pinfo, int *n)
 		}
 	}
 
-	while ((tcnt = threadsinfo(PH_THREADINFO_THREADS_ALL, PH_THREADINFO_ALL, m, info)) >= m) {
+	while ((tcnt = threadsinfo(m, PH_THREADINFO_ALL, info)) >= m) {
 		m = tcnt * 2;
 		if ((rinfo = realloc(info, m * sizeof(threadinfo_t))) == NULL) {
 			fprintf(stderr, "pm: out of memory\n");

--- a/psh/ps/ps.c
+++ b/psh/ps/ps.c
@@ -65,7 +65,7 @@ static void usage(const char *progname)
 static int psh_ps(int argc, char **argv)
 {
 	int (*cmp)(const void *, const void *) = psh_ps_cmppid;
-	int c, tcnt, i, j, n = 32;
+	int c, tcnt, i, j, n = 32, resthrds;
 	unsigned int threads = 0, fullcmd = 0;
 	threadinfo_t *info, *rinfo;
 	unsigned int d, h, m, s;
@@ -102,13 +102,18 @@ static int psh_ps(int argc, char **argv)
 		}
 	}
 
+	resthrds = threadsinfo(PH_THREADINFO_THREADS_ALL, PH_THREADINFO_OPT_THREADCOUNT, 0, NULL);
+	if (resthrds * 2 > n) {
+		n = resthrds * 2;
+	}
+
 	if ((info = malloc(n * sizeof(threadinfo_t))) == NULL) {
 		fprintf(stderr, "ps: out of memory\n");
 		return -ENOMEM;
 	}
 
-	while ((tcnt = threadsinfo(n, info)) >= n) {
-		n *= 2;
+	while ((tcnt = threadsinfo(PH_THREADINFO_THREADS_ALL, PH_THREADINFO_ALL, n, info)) >= n) {
+		n = tcnt * 2;
 		if ((rinfo = realloc(info, n * sizeof(threadinfo_t))) == NULL) {
 			fprintf(stderr, "ps: out of memory\n");
 			free(info);

--- a/psh/ps/ps.c
+++ b/psh/ps/ps.c
@@ -102,7 +102,7 @@ static int psh_ps(int argc, char **argv)
 		}
 	}
 
-	resthrds = threadsinfo(PH_THREADINFO_THREADS_ALL, PH_THREADINFO_OPT_THREADCOUNT, 0, NULL);
+	resthrds = threadsinfo(0, PH_THREADINFO_OPT_THREADCOUNT, NULL);
 	if (resthrds * 2 > n) {
 		n = resthrds * 2;
 	}
@@ -112,7 +112,7 @@ static int psh_ps(int argc, char **argv)
 		return -ENOMEM;
 	}
 
-	while ((tcnt = threadsinfo(PH_THREADINFO_THREADS_ALL, PH_THREADINFO_ALL, n, info)) >= n) {
+	while ((tcnt = threadsinfo(n, PH_THREADINFO_ALL, info)) >= n) {
 		n = tcnt * 2;
 		if ((rinfo = realloc(info, n * sizeof(threadinfo_t))) == NULL) {
 			fprintf(stderr, "ps: out of memory\n");

--- a/psh/top/top.c
+++ b/psh/top/top.c
@@ -259,7 +259,7 @@ void psh_topinfo(void)
 int psh_top(int argc, char **argv)
 {
 	int c, err = 0, cmd = 0, itermode = 1, run = 1, ret = EOK;
-	unsigned int totcnt, n = 32, delay = 3, niter = 0;
+	unsigned int totcnt, n = 32, resthrds = 0, delay = 3, niter = 0;
 	threadinfo_t *info, *rinfo, *previnfo;
 	time_t prev_time = 0;
 	struct timespec ts;
@@ -298,6 +298,11 @@ int psh_top(int argc, char **argv)
 		}
 	}
 
+	resthrds = threadsinfo(PH_THREADINFO_THREADS_ALL, PH_THREADINFO_OPT_THREADCOUNT, 0, NULL);
+	if (resthrds * 2 > n) {
+		n = resthrds * 2;
+	}
+
 	if ((info = malloc(n * sizeof(threadinfo_t))) == NULL) {
 		fprintf(stderr, "top: out of memory\n");
 		return -ENOMEM;
@@ -324,8 +329,8 @@ int psh_top(int argc, char **argv)
 
 		clock_gettime(CLOCK_MONOTONIC, &ts);
 		/* Reallocate buffers if number of threads exceeds n */
-		while ((totcnt = threadsinfo(n, info)) >= n) {
-			n *= 2;
+		while ((totcnt = threadsinfo(PH_THREADINFO_THREADS_ALL, PH_THREADINFO_ALL, n, info)) >= n) {
+			n = totcnt * 2;
 			if ((rinfo = realloc(info, n * sizeof(threadinfo_t))) == NULL) {
 				fprintf(stderr, "ps: out of memory\n");
 				psh_top_free(info, previnfo);

--- a/psh/top/top.c
+++ b/psh/top/top.c
@@ -298,7 +298,7 @@ int psh_top(int argc, char **argv)
 		}
 	}
 
-	resthrds = threadsinfo(PH_THREADINFO_THREADS_ALL, PH_THREADINFO_OPT_THREADCOUNT, 0, NULL);
+	resthrds = threadsinfo(0, PH_THREADINFO_OPT_THREADCOUNT, NULL);
 	if (resthrds * 2 > n) {
 		n = resthrds * 2;
 	}
@@ -329,7 +329,7 @@ int psh_top(int argc, char **argv)
 
 		clock_gettime(CLOCK_MONOTONIC, &ts);
 		/* Reallocate buffers if number of threads exceeds n */
-		while ((totcnt = threadsinfo(PH_THREADINFO_THREADS_ALL, PH_THREADINFO_ALL, n, info)) >= n) {
+		while ((totcnt = threadsinfo(n, PH_THREADINFO_ALL, info)) >= n) {
 			n = totcnt * 2;
 			if ((rinfo = realloc(info, n * sizeof(threadinfo_t))) == NULL) {
 				fprintf(stderr, "ps: out of memory\n");


### PR DESCRIPTION
JIRA: RTOS-1187

Depends-On: libphoenix#454

## Description
This pull request modifies programs using `threadsinfo` syscall accordingly to kernel changes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

## How Has This Been Tested?
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment
- [X] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/720
- https://github.com/phoenix-rtos/libphoenix/pull/454
- https://github.com/phoenix-rtos/phoenix-rtos-doc/pull/247
- [x] I will merge this PR by myself when appropriate.
