### PR TITLE
ls: fix psh_ls_lowmem memory leak

### DIFF
--- a/psh/ls/ls.c
+++ b/psh/ls/ls.c
@@ -265,7 +265,7 @@ static unsigned int psh_ls_numplaces(unsigned int n)
 }
 
 
-/* do a low-memory fallback - a constant memory ls print without entry sorting */
+/* do a low-memory fallback - a constant (w.r.t. filecount) memory ls print without entry sorting */
 static int psh_ls_lowmem(void)
 {
 	DIR *stream;
@@ -316,9 +316,9 @@ static int psh_ls_lowmem(void)
 				continue;
 			}
 
-			memset(&file, 0, sizeof(file));
 			if ((ret = psh_ls_readentry(&file, dir, path)) < 0) {
 				closedir(stream);
+				free(file.name);
 				return ret;
 			}
 
@@ -333,6 +333,9 @@ static int psh_ls_lowmem(void)
 			nfiles++;
 		}
 		putchar('\n');
+
+		closedir(stream);
+		free(file.name);
 	}
 
 	return EOK;


### PR DESCRIPTION
file.name is allocated with realloc in psh_ls_copyname and was never freed in lowmem mode

JIRA: RTOS-1107

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [X] Tested by hand on: nilee

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
