### PR TITLE
WIP: DO NOT MERGE - Test Depends-On branch directive (resolve-deps)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,14 @@ on:
     branches:
       - master
       - 'feature/*'
+      - 'nalajcie/*'
   pull_request:
     branches:
       - master
       - 'feature/*'
+      - 'nalajcie/*'
 
 jobs:
   call-ci:
-    uses: phoenix-rtos/phoenix-rtos-project/.github/workflows/ci-submodule.yml@master
+    uses: phoenix-rtos/phoenix-rtos-project/.github/workflows/ci-submodule.yml@nalajcie/ci
     secrets: inherit

--- a/psh/psh.c
+++ b/psh/psh.c
@@ -220,3 +220,4 @@ int main(int argc, char **argv)
 
 	return (err < 0) ? 1 : err;
 }
+/* ci-test: Depends-On branch marker */


### PR DESCRIPTION
## DO NOT MERGE - CI test PR

This is a test PR to verify the Depends-On branch directive feature of `resolve-deps.sh`.

Depends-On: phoenix-rtos-kernel:nalajcie/ci-test-deps

**Expected behavior:** CI should checkout branch `nalajcie/ci-test-deps` in `phoenix-rtos-kernel` based on the Depends-On directive above (note: different branch name than this PR's branch).

Check the 'Resolve cross-repo dependencies' step in CI logs to verify.