### PR TITLE
WIP: DO NOT MERGE - Test 2: Depends-On branch directive (resolve-deps)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
     branches:
       - master
       - 'feature/*'
-      - 'nalajcie/*'
 
 jobs:
   call-ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 # vim:sw=2:ts=2
 name: ci
 
-# on events
 on:
   push:
     branches:
@@ -11,8 +10,9 @@ on:
     branches:
       - master
       - 'feature/*'
+      - 'nalajcie/*'
 
 jobs:
   call-ci:
-    uses: phoenix-rtos/phoenix-rtos-project/.github/workflows/ci-submodule.yml@master
+    uses: phoenix-rtos/phoenix-rtos-project/.github/workflows/ci-submodule.yml@nalajcie/ci
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ This repository contains basic Phoenix-RTOS utilities e.g. psh (Phoenix SHell) a
 To learn more refer to the [Phoenix-RTOS Documentation](https://github.com/phoenix-rtos/phoenix-rtos-doc/).
 
 This work is licensed under a BSD license. See the LICENSE file for details.
+/* ci-test: depends-on branch */


### PR DESCRIPTION
Test PR for cross-repo dependency resolution.

**DO NOT MERGE**

This PR tests the Depends-On branch directive. This branch is named
`nalajcie/ci-test-depends-branch` but it explicitly depends on a *differently named*
branch in phoenix-rtos-kernel.

Depends-On: phoenix-rtos-kernel:nalajcie/ci-test-deps
Depends-On: phoenix-rtos-project:nalajcie/ci

Expected: resolve-deps.sh logs should show phoenix-rtos-kernel checked out
to `nalajcie/ci-test-deps` (via explicit Depends-On, not same-branch matching).