### PR TITLE
(pshapp, auth): use TCSADRAIN instead of TCSAFLUSH for termios setting

### DIFF
--- a/psh/pshapp/auth.c
+++ b/psh/pshapp/auth.c
@@ -41,7 +41,7 @@ static int psh_authcredentget(char *buff, int ispasswd, int maxinlen)
 	else
 		ttyattr.c_lflag |= (ICANON | ECHO | ISIG);
 
-	if (tcsetattr(STDIN_FILENO, TCSAFLUSH, &ttyattr) < 0) {
+	if (tcsetattr(STDIN_FILENO, TCSADRAIN, &ttyattr) < 0) {
 		fprintf(stderr, "psh: setting tty attributes fail\n");
 		return -ENOTTY;
 	}
@@ -90,11 +90,11 @@ static int psh_authcredentget(char *buff, int ispasswd, int maxinlen)
 	if (ispasswd || inputlen < 0)
 		fprintf(stdout, "\n");
 
-	if (tcsetattr(STDIN_FILENO, TCSAFLUSH, &origattr) < 0) {
+	if (tcsetattr(STDIN_FILENO, TCSADRAIN, &origattr) < 0) {
 		fprintf(stderr, "psh: setting tty attributes fail\n");
 		return -ENOTTY;
 	}
-	
+
 	if (inputlen >= 0)
 		return inputlen;
 

--- a/psh/pshapp/pshapp.c
+++ b/psh/pshapp/pshapp.c
@@ -597,7 +597,7 @@ static int psh_readcmd(struct termios *orig, psh_hist_t *cmdhist, char **cmd)
 	/* Enable raw mode for command processing */
 	cfmakeraw(&raw);
 
-	if ((err = tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw)) < 0) {
+	if ((err = tcsetattr(STDIN_FILENO, TCSADRAIN, &raw)) < 0) {
 		fprintf(stderr, "\npsh: failed to enable raw mode\n");
 		free(*cmd);
 		return err;
@@ -1025,7 +1025,7 @@ static int psh_readcmd(struct termios *orig, psh_hist_t *cmdhist, char **cmd)
 	}
 
 	/* Restore original terminal settings */
-	if ((esc = tcsetattr(STDIN_FILENO, TCSAFLUSH, orig)) < 0) {
+	if ((esc = tcsetattr(STDIN_FILENO, TCSADRAIN, orig)) < 0) {
 		fprintf(stderr, "\r\npsh: failed to restore terminal settings\r\n");
 		if (err >= 0)
 			err = esc;
@@ -1452,7 +1452,7 @@ static int psh_reset(int argc, char **argv)
 	term.c_iflag |= IXON | BRKINT | PARMRK;
 	term.c_oflag |= OPOST;
 
-	if (tcsetattr(STDIN_FILENO, TCSAFLUSH, &term) < 0) {
+	if (tcsetattr(STDIN_FILENO, TCSADRAIN, &term) < 0) {
 		fprintf(stderr, "reset: failed to set cooked mode\n");
 		return EXIT_FAILURE;
 	}


### PR DESCRIPTION
YT: RTOS-1355

<!--- Provide a general summary of your changes in the Title above -->

## Description
Until now, before every command, input was going to be flushed (which was not implemented in libtty). When it is implemented though, input from before the parsing of a command is started should not be flushed as we don't want to lose any characters from before the prompt is displayed to the user.

From what I've seen, e.g. GNU bash also does TCSADRAIN instead of TCSAFLUSH when setting termios attributes.

## Motivation and Context
Connected to https://github.com/phoenix-rtos/phoenix-rtos-devices/pull/671, which implements flushing/draining the input/output buffers on TCSETS/TCSETSW/TCSETSF underlying ioctl commands. It became apparent then that we're losing characters that were inputed before the prompt appeared.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
