### PR TITLE
psh/ls: don't resolve symlink

### DIFF
--- a/psh/ls/ls.c
+++ b/psh/ls/ls.c
@@ -289,7 +289,7 @@ static int psh_ls_lowmem(void)
 
 		path = psh_ls_common.paths[i];
 
-		ret = psh_ls_statentry(&file, path, true);
+		ret = psh_ls_statentry(&file, path, false);
 		if (ret < 0) {
 			fprintf(stderr, "ls: stat failed\n");
 			return ret;
@@ -625,7 +625,7 @@ int psh_ls(int argc, char **argv)
 
 	/* Try to stat all the given paths */
 	for (i = 0; i < psh_ls_common.npaths; i++) {
-		ret = psh_ls_statentry(&psh_ls_common.files[nfiles], psh_ls_common.paths[i], true);
+		ret = psh_ls_statentry(&psh_ls_common.files[nfiles], psh_ls_common.paths[i], false);
 		if (ret < 0) {
 			fprintf(stderr, "ls: can't access %s: no such file or directory\n", psh_ls_common.paths[i]);
 			continue;


### PR DESCRIPTION
JIRA: RTOS-1387

<!--- Provide a general summary of your changes in the Title above -->
`ls` cmd was resolving symlink and showing its destination attributes instead of its own.

Fixing phoenix-rtos/phoenix-rtos-project#1219

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
