### PR TITLE
pshapp: fix exit through EOT

### DIFF
--- a/psh/pshapp/pshapp.c
+++ b/psh/pshapp/pshapp.c
@@ -1568,7 +1568,6 @@ static int psh_run(int exitable, const char *console)
 	char *tmp, *cmd, **argv;
 	int cnt, err, argc, retries;
 	pid_t pgrp;
-	sigset_t mask;
 
 	/* Time for klog to print data from buffer */
 	sleep(1);
@@ -1587,10 +1586,15 @@ static int psh_run(int exitable, const char *console)
 		}
 	}
 
-	if (sigprocmask(SIG_BLOCK, NULL, &mask) == 0 && sigismember(&mask, SIGTTIN)) {
-		/* Wait till we run in foreground */
-		while ((pgrp = tcgetpgrp(STDIN_FILENO)) != -1 && pgrp != getpgrp()) {
-			if (kill(0, SIGTTIN) == -1) {
+	/* Wait till we run in foreground */
+	if (tcgetpgrp(STDIN_FILENO) != -1) {
+		for (;;) {
+			pgrp = tcgetpgrp(STDIN_FILENO);
+			if (pgrp == getpgrp()) {
+				break;
+			}
+
+			if (kill(-pgrp, SIGTTIN) == 0) {
 				break;
 			}
 		}

--- a/psh/pshapp/pshapp.c
+++ b/psh/pshapp/pshapp.c
@@ -653,6 +653,7 @@ static int psh_readcmd(struct termios *orig, psh_hist_t *cmdhist, char **cmd)
 				}
 				else if (!(n + m)) {
 					printf("exit\r\n");
+					tcsetpgrp(STDIN_FILENO, -1);
 					free(*cmd);
 					*cmd = NULL;
 					break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Properly set the PGRP on STDIN_FILENO to -1 when exiting.
<!--- Describe your changes shortly -->

## Motivation and Context
This change was needed as it was added that when a non-existent PGRP is
requested in kill(), -ESRCH was returned. The pshapp_pshappExit correctly
set the terminal to "abondoned" through tcsetpgrp with -1 as pid, but the
EOT did not, which lead to PGRP of the previous instance of psh stayng in
libtty, effectively blocking the kill loop at the start of psh_run() from
working. This change fixes the issue as we now set the PGRP in libtty to
-1 on every exit path.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `armv7a9-zynq7000-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
