### PR TITLE
psh: remove unused variables

### DIFF
--- a/psh/edit/edit.c
+++ b/psh/edit/edit.c
@@ -904,7 +904,6 @@ static int edit_open(char *filename)
 static void edit_save(void)
 {
 	int len, n = -1;
-	size_t total = 0;
 	row_t *row;
 
 	if (edit_common.filename == NULL)
@@ -928,8 +927,6 @@ static void edit_save(void)
 				n = -1;
 				break;
 			}
-
-			total += len;
 		}
 
 		fclose(f);

--- a/psh/ls/ls.c
+++ b/psh/ls/ls.c
@@ -271,7 +271,7 @@ static int psh_ls_lowmem(void)
 	DIR *stream;
 	struct dirent *dir;
 	int ret;
-	unsigned int i, nfiles = 0;
+	unsigned int i;
 	char *path;
 	char *currdir = ".";
 
@@ -309,8 +309,6 @@ static int psh_ls_lowmem(void)
 			printf("%s:\n", path);
 		}
 
-		nfiles = 0;
-
 		while ((dir = readdir(stream)) != NULL) {
 			if ((dir->d_name[0] == '.') && !psh_ls_common.all) {
 				continue;
@@ -329,8 +327,6 @@ static int psh_ls_lowmem(void)
 			psh_ls_printfile(&file, file.namelen);
 			putchar(' ');
 			colsz += file.namelen + 1;
-
-			nfiles++;
 		}
 		putchar('\n');
 


### PR DESCRIPTION
TASK: RTOS-1312

## Description
gcc-16 complains about unused variables. Remove them

## Motivation and Context
See above

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
